### PR TITLE
データをRepositoryのモックデータに入れ替える＆メンバーリストのレイアウトを整理する

### DIFF
--- a/lib/member.dart
+++ b/lib/member.dart
@@ -1,8 +1,0 @@
-class Member {
-  const Member({this.iconUrl, this.name, this.role, this.level});
-
-  final String iconUrl;
-  final String name;
-  final String role;
-  final String level;
-}

--- a/lib/member_item.dart
+++ b/lib/member_item.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 
 import 'models/user/user.dart';
 
@@ -9,34 +10,65 @@ class MemberItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      height: 100,
-      child: Row(
-        children: <Widget>[
-          Container(
-            height: 50,
-            width: 50,
-            decoration: BoxDecoration(
-              shape: BoxShape.circle,
-              image: DecorationImage(
-                fit: BoxFit.fill,
-                image: NetworkImage(user.iconUrl),
+    // return Container(
+    //   height: 100,
+    //   child: Row(
+    //     children: <Widget>[
+    //       Container(
+    //         height: 50,
+    //         width: 50,
+    //         decoration: BoxDecoration(
+    //           shape: BoxShape.circle,
+    //           image: DecorationImage(
+    //             fit: BoxFit.fill,
+    //             image: NetworkImage(user.iconUrl),
+    //           ),
+    //         ),
+    //       ),
+    //       Container(
+    //         width: 10,
+    //       ),
+    //       Column(
+    //         mainAxisAlignment: MainAxisAlignment.center,
+    //         children: [
+    //           Text(user.name),
+    //           Text(user.role),
+    //         ],
+    //       ),
+    //       Text(user.level),
+    //     ],
+    //   ),
+    // );
+    return Column(
+      children: <Widget>[
+        Divider(
+          height: 8.0,
+        ),
+        ListTile(
+          leading: CircleAvatar(
+            backgroundImage: NetworkImage(user.iconUrl),
+          ),
+          title: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: <Widget>[
+              Text(
+                user.name,
               ),
-            ),
-          ),
-          Container(
-            width: 10,
-          ),
-          Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Text(user.name),
-              Text(user.role),
+              Text(
+                'Lv.' + user.level,
+                style: TextStyle(color: Colors.grey, fontSize:14.0),
+              )
             ],
           ),
-          Text(user.level),
-        ],
-      ),
+          subtitle: Container(
+            //padding: const EdgeInsets.only(top: 5.0),
+            child: Text(
+              user.role,
+              style: TextStyle(color: Colors.grey, fontSize: 15.0),
+            ),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/member_item.dart
+++ b/lib/member_item.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/cupertino.dart';
-import 'package:shiftend/member.dart';
+
+import 'models/user/user.dart';
 
 class MemberItem extends StatelessWidget {
-  const MemberItem({this.member});
+  const MemberItem({this.user});
 
-  final Member member;
+  final User user;
 
   @override
   Widget build(BuildContext context) {
@@ -19,7 +20,7 @@ class MemberItem extends StatelessWidget {
               shape: BoxShape.circle,
               image: DecorationImage(
                 fit: BoxFit.fill,
-                image: NetworkImage(member.iconUrl),
+                image: NetworkImage(user.iconUrl),
               ),
             ),
           ),
@@ -29,11 +30,11 @@ class MemberItem extends StatelessWidget {
           Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              Text(member.name),
-              Text(member.role),
+              Text(user.name),
+              Text(user.role),
             ],
           ),
-          Text(member.level),
+          Text(user.level),
         ],
       ),
     );

--- a/lib/member_page.dart
+++ b/lib/member_page.dart
@@ -8,16 +8,23 @@ import 'package:shiftend/models/models.dart';
 class MemberPage extends StatelessWidget {
   final UserRepositoryInterface userRepository = UserRepositoryMock();
   @override
-  Widget build(BuildContext context) async {
-    List<User> _users = await userRepository.getUsers(); 
-    // asyncとawatは別関数で管理する必要がある？
+  Widget build(BuildContext context) {
     return Scaffold(
-      body: ListView.builder(
-        //itemCount: _mockData.length,
-        itemBuilder: (context, int index) {
-          return MemberItem(member: _users[index]);
-        },
-      ),
-    );
+        body: FutureBuilder(
+      future: userRepository.getUsers(),
+      builder: (context, AsyncSnapshot<List<User>> snapshot) {
+        if (snapshot.connectionState == ConnectionState.none &&
+            snapshot.hasData == null) {
+          // 非同期処理でまだデータが何も入ってきていない．
+          return Container();
+        }
+        return ListView.builder(
+          itemCount: snapshot.data.length,
+          itemBuilder: (context, index) {
+            return MemberItem(user: snapshot.data[index]);
+          },
+        );
+      },
+    ));
   }
 }

--- a/lib/member_page.dart
+++ b/lib/member_page.dart
@@ -14,15 +14,15 @@ class MemberPage extends StatelessWidget {
       future: userRepository.getUsers(),
       builder: (context, AsyncSnapshot<List<User>> snapshot) {
         if (snapshot.hasData) {
-          // 非同期処理でまだデータが何も入ってきていない．
-          return Container();
+          return ListView.builder(
+            itemCount: snapshot.data.length,
+            itemBuilder: (context, index) {
+              return MemberItem(user: snapshot.data[index]);
+            },
+          );
+        }else{
+          return Center(child:CircularProgressIndicator());
         }
-        return ListView.builder(
-          itemCount: snapshot.data.length,
-          itemBuilder: (context, index) {
-            return MemberItem(user: snapshot.data[index]);
-          },
-        );
       },
     ));
   }

--- a/lib/member_page.dart
+++ b/lib/member_page.dart
@@ -13,8 +13,7 @@ class MemberPage extends StatelessWidget {
         body: FutureBuilder(
       future: userRepository.getUsers(),
       builder: (context, AsyncSnapshot<List<User>> snapshot) {
-        if (snapshot.connectionState == ConnectionState.none &&
-            snapshot.hasData == null) {
+        if (snapshot.hasData) {
           // 非同期処理でまだデータが何も入ってきていない．
           return Container();
         }

--- a/lib/member_page.dart
+++ b/lib/member_page.dart
@@ -1,37 +1,21 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:shiftend/member.dart';
 import 'package:shiftend/member_item.dart';
+import 'package:shiftend/repositories/interfaces/user_repository_interface.dart';
+import 'package:shiftend/repositories/mocks/user_repository_mock.dart';
+import 'package:shiftend/models/models.dart';
 
 class MemberPage extends StatelessWidget {
+  final UserRepositoryInterface userRepository = UserRepositoryMock();
   @override
-  Widget build(BuildContext context) {
-    const _mockData = [
-      Member(
-          iconUrl:
-              'https://tblg.k-img.com/restaurant/images/Rvw/29971/640x640_rect_29971374.jpg',
-          name: '佐藤勇一郎',
-          role: 'オーナー',
-          level: '100'),
-      Member(
-          iconUrl:
-              'https://tblg.k-img.com/restaurant/images/Rvw/29971/640x640_rect_29971374.jpg',
-          name: '工藤大輔',
-          role: 'オナー',
-          level: '100'),
-      Member(
-          iconUrl:
-              'https://tblg.k-img.com/restaurant/images/Rvw/29971/640x640_rect_29971374.jpg',
-          name: '松山航',
-          role: 'バイトリーダ',
-          level: '100'),
-    ];
-
+  Widget build(BuildContext context) async {
+    List<User> _users = await userRepository.getUsers(); 
+    // asyncとawatは別関数で管理する必要がある？
     return Scaffold(
       body: ListView.builder(
-        itemCount: _mockData.length,
+        //itemCount: _mockData.length,
         itemBuilder: (context, int index) {
-          return MemberItem(member: _mockData[index]);
+          return MemberItem(member: _users[index]);
         },
       ),
     );

--- a/lib/repositories/interfaces/user_repository_interface.dart
+++ b/lib/repositories/interfaces/user_repository_interface.dart
@@ -4,4 +4,5 @@ abstract class UserRepositoryInterface {
   Future<void> create(User user);
   Future<void> update(User user);
   Future<User> getCurrentUser();
+  Future<List<User>> getUsers();
 }

--- a/lib/repositories/mocks/user_repository_mock.dart
+++ b/lib/repositories/mocks/user_repository_mock.dart
@@ -28,7 +28,7 @@ class UserRepositoryMock extends UserRepositoryInterface {
             'https://tblg.k-img.com/restaurant/images/Rvw/29971/640x640_rect_29971374.jpg',
         name: '松山 航',
         role: 'バイトリーダ',
-        level: '100'),
+        level: '50'),
   ];
   User currentUser = User(
       id: 'test_user',

--- a/lib/repositories/mocks/user_repository_mock.dart
+++ b/lib/repositories/mocks/user_repository_mock.dart
@@ -4,7 +4,32 @@ import 'package:shiftend/repositories/interfaces/user_repository_interface.dart'
 import 'package:shiftend/models/models.dart';
 
 class UserRepositoryMock extends UserRepositoryInterface {
-  List<User> users = <User>[];
+  List<User> users = <User>[
+    User(
+        id: '0',
+        email: 'test@example.com',
+        iconUrl:
+            'https://tblg.k-img.com/restaurant/images/Rvw/29971/640x640_rect_29971374.jpg',
+        name: '佐藤 勇一郎',
+        role: 'オーナー',
+        level: '100'),
+    User(
+        id: '1',
+        email: 'test@example.com',
+        iconUrl:
+            'https://tblg.k-img.com/restaurant/images/Rvw/29971/640x640_rect_29971374.jpg',
+        name: '工藤 大輔',
+        role: 'オーナー',
+        level: '100'),
+    User(
+        id: '2',
+        email: 'test@example.com',
+        iconUrl:
+            'https://tblg.k-img.com/restaurant/images/Rvw/29971/640x640_rect_29971374.jpg',
+        name: '松山 航',
+        role: 'バイトリーダ',
+        level: '100'),
+  ];
   User currentUser = User(
       id: 'test_user',
       email: 'test@example.com',
@@ -34,4 +59,11 @@ class UserRepositoryMock extends UserRepositoryInterface {
     });
     return Future.value();
   }
+
+  @override
+  Future<List<User>> getUsers() async {
+    return users;
+  }
+
+  
 }

--- a/lib/repositories/user_repository.dart
+++ b/lib/repositories/user_repository.dart
@@ -41,4 +41,11 @@ class UserRepository extends UserRepositoryInterface {
         await firestore.collection(collectionName).document(uid).get();
     return User.fromJson(snapshot.data);
   }
+
+  @override
+  Future<List<User>> getUsers() async {
+    // TODO: implement getUsers
+    
+    throw UnimplementedError();
+  }
 }


### PR DESCRIPTION
## 対応するissue
- [#23｜メンバーリストのレイアウト整える](https://github.com/team-x-fun/shiftend/issues/23)
- 
## 概要

## 変更点・追加点
- ローカルのdartファイルで管理していたユーザ情報をRepositoryのモックに置き換えた
- 
-
## 使い方/バグ再現手順
- 
- 
- 
## スクリーンショット等
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## コードレビューチェックリスト
- [ ] 仕様と実装はあっている
- [ ] 無意味なロジックがない
- [ ] DRYを守っている
- [ ] テストが適切に書かれている
- [ ] メソッド名、変数名などが適切
- [ ] コーディングルールを守れている
- [ ] メソッドからは予想できない副作用が含まれていない

チェックした人：
WidgetでFuture/asyncの使い方がわからず永遠にエラー吐かれる．StatefullにしたりFutureを別に分けたり色々Try&Error繰り返したけどうまくいかなかったからとりあえず原型が見える程度まで戻している（Widget部分でエラー出る状態）
