### PR TITLE
CalendarPageのリファクタ

### DIFF
--- a/lib/debug_views/debug_page.dart
+++ b/lib/debug_views/debug_page.dart
@@ -9,32 +9,38 @@ import 'globals.dart' as globals;
 class DebugPage extends StatelessWidget {
   final UserRepository userRepo =
       UserRepository(auth: globals.auth, firestore: Firestore.instance);
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-        body: Column(children: <Widget>[
-      FlatButton(
-        child: const Text('user load'),
-        onPressed: () {
-          print('pressed user load');
-          _getUser(context);
-        },
+      body: SafeArea(
+        child: Column(
+          children: <Widget>[
+            FlatButton(
+              child: const Text('user load'),
+              onPressed: () {
+                print('pressed user load');
+                _getUser(context);
+              },
+            ),
+            FlatButton(
+              child: const Text('user login'),
+              onPressed: () {
+                print('pressed user login');
+                showBasicDialog(context);
+              },
+            ),
+            FlatButton(
+              child: const Text('user update'),
+              onPressed: () {
+                print('pressed user update');
+                _updateUser(context);
+              },
+            )
+          ],
+        ),
       ),
-      FlatButton(
-        child: const Text('user login'),
-        onPressed: () {
-          print('pressed user login');
-          showBasicDialog(context);
-        },
-      ),
-      FlatButton(
-        child: const Text('user update'),
-        onPressed: () {
-          print('pressed user update');
-          _updateUser(context);
-        },
-      ),
-    ]));
+    );
   }
 
   Future _getUser(BuildContext context) async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_state_notifier/flutter_state_notifier.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:shiftend/debug_views/debug_page.dart';
+import 'package:shiftend/pages/calendar/calendar_state_controller.dart';
+import 'package:shiftend/pages/calendar/calendar_state.dart';
 import 'package:shiftend/member_page.dart';
 import 'package:shiftend/pages/calendar/calendar_page.dart';
 import 'package:shiftend/pages/setting/setting_page.dart';
@@ -39,24 +42,27 @@ class _MainState extends State<Main> {
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: _pages[_currentIndex],
-      bottomNavigationBar: BottomNavigationBar(
-        fixedColor: Colors.black,
-        unselectedItemColor: Colors.grey,
-        onTap: onTapped,
-        currentIndex: _currentIndex,
-        type: BottomNavigationBarType.shifting,
-        items: [
-          BottomNavigationBarItem(
-              icon: Icon(Icons.calendar_today), title: Text('カレンダー')),
-          BottomNavigationBarItem(
-              icon: Icon(Icons.person), title: Text('メンバー')),
-          BottomNavigationBarItem(
-              icon: Icon(Icons.settings), title: Text('設定')),
-          BottomNavigationBarItem(
-              icon: Icon(Icons.settings), title: Text('debug')),
-        ],
+    return StateNotifierProvider<CalendarStateController, CalendarState>(
+      create: (context) => CalendarStateController(),
+      child: Scaffold(
+        body: _pages[_currentIndex],
+        bottomNavigationBar: BottomNavigationBar(
+          fixedColor: Colors.black,
+          unselectedItemColor: Colors.grey,
+          onTap: onTapped,
+          currentIndex: _currentIndex,
+          type: BottomNavigationBarType.shifting,
+          items: [
+            BottomNavigationBarItem(
+                icon: Icon(Icons.calendar_today), title: Text('カレンダー')),
+            BottomNavigationBarItem(
+                icon: Icon(Icons.person), title: Text('メンバー')),
+            BottomNavigationBarItem(
+                icon: Icon(Icons.settings), title: Text('設定')),
+            BottomNavigationBarItem(
+                icon: Icon(Icons.settings), title: Text('debug')),
+          ],
+        ),
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_state_notifier/flutter_state_notifier.dart';
 import 'package:intl/date_symbol_data_local.dart';
+import 'package:provider/provider.dart';
 import 'package:shiftend/debug_views/debug_page.dart';
 import 'package:shiftend/pages/calendar/calendar_state_controller.dart';
 import 'package:shiftend/pages/calendar/calendar_state.dart';
@@ -42,8 +43,12 @@ class _MainState extends State<Main> {
 
   @override
   Widget build(BuildContext context) {
-    return StateNotifierProvider<CalendarStateController, CalendarState>(
-      create: (context) => CalendarStateController(),
+    return MultiProvider(
+      providers: [
+        StateNotifierProvider<CalendarStateController, CalendarState>(
+          create: (_) => CalendarStateController(),
+        )
+      ],
       child: Scaffold(
         body: _pages[_currentIndex],
         bottomNavigationBar: BottomNavigationBar(

--- a/lib/pages/calendar/calendar_page.dart
+++ b/lib/pages/calendar/calendar_page.dart
@@ -1,10 +1,9 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'package:shiftend/models/models.dart';
-import 'package:shiftend/pages/calendar/calendar_state_controller.dart';
 import 'package:shiftend/pages/calendar/calendar_state.dart';
+import 'package:shiftend/pages/calendar/widgets/calendar_widget.dart';
 import 'package:shiftend/util/formatters.dart';
 import 'package:table_calendar/table_calendar.dart';
 
@@ -54,7 +53,11 @@ class _CalendarPageState extends State<CalendarPage>
         child: Column(
           mainAxisSize: MainAxisSize.max,
           children: <Widget>[
-            _buildTableCalendar(),
+//            _buildTableCalendar(),
+            CalendarWidget(
+              calendarController: _calendarController,
+              animationController: _animationController,
+            ),
             ConstrainedBox(
               constraints: BoxConstraints.expand(height: 20),
               child: Container(
@@ -69,131 +72,6 @@ class _CalendarPageState extends State<CalendarPage>
                   Provider.of<CalendarState>(context).selectedAttendees),
             ),
           ],
-        ),
-      ),
-    );
-  }
-
-  // TODO: この辺もStatelessにしたときにファイルわける
-  Widget _buildTableCalendar() {
-    return TableCalendar(
-      locale: 'ja_JP',
-      calendarController: _calendarController,
-//      events: _attendees,
-      events: Provider.of<CalendarState>(context, listen: true).attendees,
-      initialCalendarFormat: CalendarFormat.month,
-      formatAnimation: FormatAnimation.slide,
-      startingDayOfWeek: StartingDayOfWeek.sunday,
-      availableGestures: AvailableGestures.horizontalSwipe,
-      calendarStyle: CalendarStyle(
-        outsideDaysVisible: true,
-        outsideWeekendStyle: TextStyle().copyWith(color: Colors.black),
-        weekdayStyle: TextStyle().copyWith(color: Colors.black),
-        weekendStyle: TextStyle().copyWith(color: Colors.black),
-      ),
-      daysOfWeekStyle: DaysOfWeekStyle(
-        weekdayStyle: TextStyle().copyWith(color: Colors.black),
-        weekendStyle: TextStyle().copyWith(color: Colors.black),
-      ),
-      headerStyle: HeaderStyle(
-        centerHeaderTitle: true,
-        formatButtonVisible: false,
-        formatButtonShowsNext: true,
-      ),
-      builders: CalendarBuilders(
-        selectedDayBuilder: (context, date, _) {
-          return FadeTransition(
-            opacity: Tween(begin: 0.0, end: 1.0).animate(_animationController),
-            // 日付選択されたときのレイアウト
-            child: Container(
-              decoration: BoxDecoration(
-                shape: BoxShape.circle,
-                color: (date.year == DateTime.now().year &&
-                        date.month == DateTime.now().month &&
-                        date.day == DateTime.now().day)
-                    ? Colors.blue
-                    : Colors.white.withOpacity(1),
-                border: Border.all(
-                  width: 2.0,
-                  color: Colors.grey,
-                ),
-              ),
-              margin: const EdgeInsets.all(4.0),
-              padding: const EdgeInsets.only(top: 5.0, left: 6.0),
-              width: 100,
-              height: 100,
-              child: Text(
-                '${date.day}',
-                style: TextStyle().copyWith(fontSize: 16.0),
-              ),
-            ),
-          );
-        },
-        todayDayBuilder: (context, date, _) {
-          // 今日を表すレイアウト
-          return Container(
-            decoration: BoxDecoration(
-              color: Colors.blue,
-              shape: BoxShape.circle,
-            ),
-            margin: const EdgeInsets.all(4.0),
-//            padding: const EdgeInsets.only(top: 5.0, left: 6.0),
-//            color: const Color(0xFFEDFAF1),
-            width: 100,
-            height: 100,
-            child: Center(
-              child: Text(
-                '${date.day}',
-                style: TextStyle().copyWith(fontSize: 16.0),
-              ),
-            ),
-          );
-        },
-        markersBuilder: (context, date, attendees, holidays) {
-          final children = <Widget>[];
-          if (attendees.isNotEmpty) {
-            children.add(
-              Positioned(
-                right: 1,
-                bottom: 1,
-                child: _buildAttendeesMarker(date, attendees),
-              ),
-            );
-          }
-          return children;
-        },
-      ),
-      onDaySelected: (date, attendees) {
-        Provider.of<CalendarStateController>(context, listen: false)
-            .onDaySelected(date, attendees.cast<User>());
-        _animationController.forward(from: 0.0);
-      },
-      onVisibleDaysChanged: _onVisibleDaysChanged,
-      onCalendarCreated: _onCalendarCreated,
-    );
-  }
-
-  Widget _buildAttendeesMarker(DateTime date, List attendees) {
-    return AnimatedContainer(
-      duration: const Duration(milliseconds: 300),
-      decoration: BoxDecoration(
-        shape: BoxShape.rectangle,
-        color: Colors.pink,
-//        color: _calendarController.isSelected(date)
-//            ? Colors.brown[500]
-//            : _calendarController.isToday(date)
-//                ? Colors.brown[300]
-//                : Colors.blue[400],
-      ),
-      width: 16.0,
-      height: 16.0,
-      child: Center(
-        child: Text(
-          '${attendees.length}',
-          style: TextStyle().copyWith(
-            color: Colors.white,
-            fontSize: 12.0,
-          ),
         ),
       ),
     );

--- a/lib/pages/calendar/calendar_page.dart
+++ b/lib/pages/calendar/calendar_page.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:shiftend/models/models.dart';
 import 'package:shiftend/pages/calendar/calendar_state.dart';
+import 'package:shiftend/pages/calendar/widgets/calendar_list_widget.dart';
 import 'package:shiftend/pages/calendar/widgets/calendar_widget.dart';
 import 'package:shiftend/util/formatters.dart';
 import 'package:table_calendar/table_calendar.dart';
@@ -53,7 +53,6 @@ class _CalendarPageState extends State<CalendarPage>
         child: Column(
           mainAxisSize: MainAxisSize.max,
           children: <Widget>[
-//            _buildTableCalendar(),
             CalendarWidget(
               calendarController: _calendarController,
               animationController: _animationController,
@@ -68,39 +67,14 @@ class _CalendarPageState extends State<CalendarPage>
               ),
             ),
             Expanded(
-              child: _buildAttendanceList(
-                  Provider.of<CalendarState>(context).selectedAttendees),
+              child: CalendarListWidget(
+                attendees:
+                    Provider.of<CalendarState>(context).selectedAttendees,
+              ),
             ),
           ],
         ),
       ),
     );
-  }
-
-  Widget _buildAttendanceList(List<User> selectedAttendees) {
-    Widget child = Container(
-      color: Colors.pink,
-    );
-    if (selectedAttendees != null) {
-      child = ListView(
-        children: selectedAttendees
-            .map<Container>(
-              (attendee) => Container(
-                decoration: BoxDecoration(
-                  border: Border.all(width: 0.8),
-                  borderRadius: BorderRadius.circular(12.0),
-                ),
-                margin:
-                    const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
-                child: ListTile(
-                  title: Text(attendee.toString()),
-                  onTap: () => print('$attendee tapped'),
-                ),
-              ),
-            )
-            .toList(),
-      );
-    }
-    return child;
   }
 }

--- a/lib/pages/calendar/calendar_page.dart
+++ b/lib/pages/calendar/calendar_page.dart
@@ -36,16 +36,6 @@ class _CalendarPageState extends State<CalendarPage>
     super.dispose();
   }
 
-  void _onVisibleDaysChanged(
-      DateTime first, DateTime last, CalendarFormat format) {
-    print('CALLBACK: _onVisibleDaysChanged');
-  }
-
-  void _onCalendarCreated(
-      DateTime first, DateTime last, CalendarFormat format) {
-    print('CALLBACK: _onCalendarCreated');
-  }
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(

--- a/lib/pages/calendar/calendar_state.dart
+++ b/lib/pages/calendar/calendar_state.dart
@@ -1,0 +1,13 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:shiftend/models/models.dart';
+
+part 'calendar_state.freezed.dart';
+
+@freezed
+abstract class CalendarState with _$CalendarState {
+  const factory CalendarState({
+    Map<DateTime, List<User>> attendees,
+    DateTime selectedDate,
+    List<User> selectedAttendees,
+  }) = _CalendarState;
+}

--- a/lib/pages/calendar/calendar_state.freezed.dart
+++ b/lib/pages/calendar/calendar_state.freezed.dart
@@ -1,0 +1,175 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named
+
+part of 'calendar_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+class _$CalendarStateTearOff {
+  const _$CalendarStateTearOff();
+
+  _CalendarState call(
+      {Map<DateTime, List<User>> attendees,
+      DateTime selectedDate,
+      List<User> selectedAttendees}) {
+    return _CalendarState(
+      attendees: attendees,
+      selectedDate: selectedDate,
+      selectedAttendees: selectedAttendees,
+    );
+  }
+}
+
+// ignore: unused_element
+const $CalendarState = _$CalendarStateTearOff();
+
+mixin _$CalendarState {
+  Map<DateTime, List<User>> get attendees;
+  DateTime get selectedDate;
+  List<User> get selectedAttendees;
+
+  $CalendarStateCopyWith<CalendarState> get copyWith;
+}
+
+abstract class $CalendarStateCopyWith<$Res> {
+  factory $CalendarStateCopyWith(
+          CalendarState value, $Res Function(CalendarState) then) =
+      _$CalendarStateCopyWithImpl<$Res>;
+  $Res call(
+      {Map<DateTime, List<User>> attendees,
+      DateTime selectedDate,
+      List<User> selectedAttendees});
+}
+
+class _$CalendarStateCopyWithImpl<$Res>
+    implements $CalendarStateCopyWith<$Res> {
+  _$CalendarStateCopyWithImpl(this._value, this._then);
+
+  final CalendarState _value;
+  // ignore: unused_field
+  final $Res Function(CalendarState) _then;
+
+  @override
+  $Res call({
+    Object attendees = freezed,
+    Object selectedDate = freezed,
+    Object selectedAttendees = freezed,
+  }) {
+    return _then(_value.copyWith(
+      attendees: attendees == freezed
+          ? _value.attendees
+          : attendees as Map<DateTime, List<User>>,
+      selectedDate: selectedDate == freezed
+          ? _value.selectedDate
+          : selectedDate as DateTime,
+      selectedAttendees: selectedAttendees == freezed
+          ? _value.selectedAttendees
+          : selectedAttendees as List<User>,
+    ));
+  }
+}
+
+abstract class _$CalendarStateCopyWith<$Res>
+    implements $CalendarStateCopyWith<$Res> {
+  factory _$CalendarStateCopyWith(
+          _CalendarState value, $Res Function(_CalendarState) then) =
+      __$CalendarStateCopyWithImpl<$Res>;
+  @override
+  $Res call(
+      {Map<DateTime, List<User>> attendees,
+      DateTime selectedDate,
+      List<User> selectedAttendees});
+}
+
+class __$CalendarStateCopyWithImpl<$Res>
+    extends _$CalendarStateCopyWithImpl<$Res>
+    implements _$CalendarStateCopyWith<$Res> {
+  __$CalendarStateCopyWithImpl(
+      _CalendarState _value, $Res Function(_CalendarState) _then)
+      : super(_value, (v) => _then(v as _CalendarState));
+
+  @override
+  _CalendarState get _value => super._value as _CalendarState;
+
+  @override
+  $Res call({
+    Object attendees = freezed,
+    Object selectedDate = freezed,
+    Object selectedAttendees = freezed,
+  }) {
+    return _then(_CalendarState(
+      attendees: attendees == freezed
+          ? _value.attendees
+          : attendees as Map<DateTime, List<User>>,
+      selectedDate: selectedDate == freezed
+          ? _value.selectedDate
+          : selectedDate as DateTime,
+      selectedAttendees: selectedAttendees == freezed
+          ? _value.selectedAttendees
+          : selectedAttendees as List<User>,
+    ));
+  }
+}
+
+class _$_CalendarState implements _CalendarState {
+  const _$_CalendarState(
+      {this.attendees, this.selectedDate, this.selectedAttendees});
+
+  @override
+  final Map<DateTime, List<User>> attendees;
+  @override
+  final DateTime selectedDate;
+  @override
+  final List<User> selectedAttendees;
+
+  @override
+  String toString() {
+    return 'CalendarState(attendees: $attendees, selectedDate: $selectedDate, selectedAttendees: $selectedAttendees)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other is _CalendarState &&
+            (identical(other.attendees, attendees) ||
+                const DeepCollectionEquality()
+                    .equals(other.attendees, attendees)) &&
+            (identical(other.selectedDate, selectedDate) ||
+                const DeepCollectionEquality()
+                    .equals(other.selectedDate, selectedDate)) &&
+            (identical(other.selectedAttendees, selectedAttendees) ||
+                const DeepCollectionEquality()
+                    .equals(other.selectedAttendees, selectedAttendees)));
+  }
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^
+      const DeepCollectionEquality().hash(attendees) ^
+      const DeepCollectionEquality().hash(selectedDate) ^
+      const DeepCollectionEquality().hash(selectedAttendees);
+
+  @override
+  _$CalendarStateCopyWith<_CalendarState> get copyWith =>
+      __$CalendarStateCopyWithImpl<_CalendarState>(this, _$identity);
+}
+
+abstract class _CalendarState implements CalendarState {
+  const factory _CalendarState(
+      {Map<DateTime, List<User>> attendees,
+      DateTime selectedDate,
+      List<User> selectedAttendees}) = _$_CalendarState;
+
+  @override
+  Map<DateTime, List<User>> get attendees;
+  @override
+  DateTime get selectedDate;
+  @override
+  List<User> get selectedAttendees;
+  @override
+  _$CalendarStateCopyWith<_CalendarState> get copyWith;
+}

--- a/lib/pages/calendar/calendar_state_controller.dart
+++ b/lib/pages/calendar/calendar_state_controller.dart
@@ -1,0 +1,82 @@
+import 'package:intl/intl.dart';
+import 'package:shiftend/models/models.dart';
+import 'package:shiftend/pages/calendar/calendar_state.dart';
+import 'package:state_notifier/state_notifier.dart';
+
+class CalendarStateController extends StateNotifier<CalendarState>
+    with LocatorMixin {
+  CalendarStateController() : super(const CalendarState());
+
+  @override
+  void initState() {
+    super.initState();
+    final Map<DateTime, List<User>> _dummyAttendees = {
+      DateTime.parse('2020-07-10'): [
+        User(
+            id: '0',
+            email: '',
+            name: '未来太郎',
+            role: 'バイトリーダー',
+            level: '50',
+            iconUrl: ''),
+        User(
+            id: '1',
+            email: '',
+            name: '未来花子',
+            role: '',
+            level: '50',
+            iconUrl: ''),
+      ],
+      DateTime.parse('2020-07-20'): [
+        User(
+            id: '0',
+            email: '',
+            name: '未来太郎',
+            role: 'バイトリーダー',
+            level: '50',
+            iconUrl: ''),
+        User(
+            id: '1',
+            email: '',
+            name: '未来花子',
+            role: '',
+            level: '50',
+            iconUrl: ''),
+        User(
+            id: '2',
+            email: '',
+            name: '未来次郎',
+            role: '',
+            level: '50',
+            iconUrl: ''),
+      ],
+      DateTime.parse('2020-07-22'): [
+        User(
+            id: '0',
+            email: '',
+            name: '未来太郎',
+            role: 'バイトリーダー',
+            level: '50',
+            iconUrl: ''),
+        User(
+            id: '1',
+            email: '',
+            name: '未来花子',
+            role: '',
+            level: '50',
+            iconUrl: ''),
+      ],
+    };
+    state = state.copyWith(attendees: _dummyAttendees);
+    state = state.copyWith(selectedDate: DateTime.now());
+    final _dateFormatter = DateFormat('yyyy-MM-dd');
+    final _formattedNow = _dateFormatter.format(state.selectedDate);
+    state = state.copyWith(
+        selectedAttendees: state.attendees[DateTime.parse(_formattedNow)]);
+  }
+
+  void onDaySelected(DateTime day, List<User> attendees) {
+    state = state.copyWith(selectedDate: day);
+    state = state.copyWith(selectedAttendees: attendees);
+  }
+}

--- a/lib/pages/calendar/widgets/calendar_list_widget.dart
+++ b/lib/pages/calendar/widgets/calendar_list_widget.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:shiftend/models/models.dart';
+
+class CalendarListWidget extends StatelessWidget {
+  const CalendarListWidget({this.attendees});
+
+  final List<User> attendees;
+
+  @override
+  Widget build(BuildContext context) {
+    Widget child = Container();
+    if (attendees != null) {
+      child = ListView(
+        children: attendees
+            .map(
+              (attendee) => Container(
+                decoration: BoxDecoration(
+                  border: Border.all(width: 0.8),
+                  borderRadius: BorderRadius.circular(12.0),
+                ),
+                margin:
+                    const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
+                child: ListTile(
+                  title: Text(attendee.toString()),
+                  onTap: () => print('$attendee tapped'),
+                ),
+              ),
+            )
+            .toList(),
+      );
+    }
+    return child;
+  }
+}

--- a/lib/pages/calendar/widgets/calendar_widget.dart
+++ b/lib/pages/calendar/widgets/calendar_widget.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:shiftend/models/models.dart';
+import 'package:shiftend/pages/calendar/calendar_state.dart';
+import 'package:shiftend/pages/calendar/calendar_state_controller.dart';
+import 'package:shiftend/pages/calendar/widgets/marker_widget.dart';
+import 'package:table_calendar/table_calendar.dart';
+
+class CalendarWidget extends StatelessWidget {
+  const CalendarWidget({this.calendarController, this.animationController});
+
+  @required
+  final CalendarController calendarController;
+  @required
+  final AnimationController animationController;
+
+  @override
+  Widget build(BuildContext context) {
+    return TableCalendar(
+      locale: 'ja_JP',
+      calendarController: calendarController,
+      events: Provider.of<CalendarState>(context, listen: true).attendees,
+      initialCalendarFormat: CalendarFormat.month,
+      formatAnimation: FormatAnimation.slide,
+      startingDayOfWeek: StartingDayOfWeek.sunday,
+      availableGestures: AvailableGestures.horizontalSwipe,
+      calendarStyle: CalendarStyle(
+        outsideDaysVisible: true,
+        outsideWeekendStyle: TextStyle().copyWith(color: Colors.black),
+        weekdayStyle: TextStyle().copyWith(color: Colors.black),
+        weekendStyle: TextStyle().copyWith(color: Colors.black),
+      ),
+      daysOfWeekStyle: DaysOfWeekStyle(
+        weekdayStyle: TextStyle().copyWith(color: Colors.black),
+        weekendStyle: TextStyle().copyWith(color: Colors.black),
+      ),
+      headerStyle: HeaderStyle(
+        centerHeaderTitle: true,
+        formatButtonVisible: false,
+        formatButtonShowsNext: true,
+      ),
+      builders: CalendarBuilders(
+        selectedDayBuilder: (context, date, _) {
+          return FadeTransition(
+            opacity: Tween(begin: 0.0, end: 1.0).animate(animationController),
+            // 日付選択されたときのレイアウト
+            child: Container(
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: (date.year == DateTime.now().year &&
+                        date.month == DateTime.now().month &&
+                        date.day == DateTime.now().day)
+                    ? Colors.blue
+                    : Colors.white.withOpacity(1),
+                border: Border.all(
+                  width: 2.0,
+                  color: Colors.grey,
+                ),
+              ),
+              margin: const EdgeInsets.all(4.0),
+              padding: const EdgeInsets.only(top: 5.0, left: 6.0),
+              width: 100,
+              height: 100,
+              child: Text(
+                '${date.day}',
+                style: TextStyle().copyWith(fontSize: 16.0),
+              ),
+            ),
+          );
+        },
+        todayDayBuilder: (context, date, _) {
+          // 今日を表すレイアウト
+          return Container(
+            decoration: BoxDecoration(
+              color: Colors.blue,
+              shape: BoxShape.circle,
+            ),
+            margin: const EdgeInsets.all(4.0),
+//            padding: const EdgeInsets.only(top: 5.0, left: 6.0),
+//            color: const Color(0xFFEDFAF1),
+            width: 100,
+            height: 100,
+            child: Center(
+              child: Text(
+                '${date.day}',
+                style: TextStyle().copyWith(fontSize: 16.0),
+              ),
+            ),
+          );
+        },
+        markersBuilder: (context, date, attendees, holidays) {
+          final children = <Widget>[];
+          if (attendees.isNotEmpty) {
+            children.add(
+              Positioned(
+                right: 1,
+                bottom: 1,
+                child: MarkerWidget(
+                  date: date,
+                  attendees: attendees,
+                ),
+              ),
+            );
+          }
+          return children;
+        },
+      ),
+      onDaySelected: (date, attendees) {
+        Provider.of<CalendarStateController>(context, listen: false)
+            .onDaySelected(date, attendees.cast<User>());
+        animationController.forward(from: 0.0);
+      },
+    );
+  }
+}

--- a/lib/pages/calendar/widgets/marker_widget.dart
+++ b/lib/pages/calendar/widgets/marker_widget.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:shiftend/models/models.dart';
 
 class MarkerWidget extends StatelessWidget {
   const MarkerWidget({this.date, this.attendees});

--- a/lib/pages/calendar/widgets/marker_widget.dart
+++ b/lib/pages/calendar/widgets/marker_widget.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:shiftend/models/models.dart';
+
+class MarkerWidget extends StatelessWidget {
+  const MarkerWidget({this.date, this.attendees});
+
+  final DateTime date;
+  final List attendees;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 300),
+      decoration: BoxDecoration(
+        shape: BoxShape.rectangle,
+        color: Colors.pink,
+//        color: _calendarController.isSelected(date)
+//            ? Colors.brown[500]
+//            : _calendarController.isToday(date)
+//                ? Colors.brown[300]
+//                : Colors.blue[400],
+      ),
+      width: 16.0,
+      height: 16.0,
+      child: Center(
+        child: Text(
+          '${attendees.length}',
+          style: TextStyle().copyWith(color: Colors.white, fontSize: 12.0),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/util/formatters.dart
+++ b/lib/util/formatters.dart
@@ -1,0 +1,5 @@
+import 'package:intl/intl.dart';
+
+String fullDateToJa(DateTime date) {
+  return '${date.year}年${date.month}月${date.day}日${DateFormat('EEEE', 'ja').format(date)}';
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -258,6 +258,13 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_state_notifier:
+    dependency: "direct main"
+    description:
+      name: flutter_state_notifier
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.4.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -276,7 +283,7 @@ packages:
     source: hosted
     version: "0.11.2"
   freezed_annotation:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: freezed_annotation
       url: "https://pub.dartlang.org"
@@ -332,7 +339,7 @@ packages:
     source: hosted
     version: "2.1.12"
   intl:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: intl
       url: "https://pub.dartlang.org"
@@ -394,6 +401,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.9.6+3"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.4"
   node_interop:
     dependency: transitive
     description:
@@ -457,6 +471,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.4.0"
+  provider:
+    dependency: "direct main"
+    description:
+      name: provider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.3.0"
   pub_semver:
     dependency: transitive
     description:
@@ -525,6 +546,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.9.3"
+  state_notifier:
+    dependency: "direct main"
+    description:
+      name: state_notifier
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.0"
   stream_channel:
     dependency: transitive
     description:
@@ -618,4 +646,8 @@ packages:
     version: "2.2.1"
 sdks:
   dart: ">=2.7.0 <3.0.0"
+<<<<<<< HEAD
   flutter: "1.17.5"
+=======
+  flutter: ">=1.16.0 <2.0.0"
+>>>>>>> introduce freezed and state notifier

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -646,8 +646,4 @@ packages:
     version: "2.2.1"
 sdks:
   dart: ">=2.7.0 <3.0.0"
-<<<<<<< HEAD
   flutter: "1.17.5"
-=======
-  flutter: ">=1.16.0 <2.0.0"
->>>>>>> introduce freezed and state notifier

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,20 +1,7 @@
 name: shiftend
 description: A new Flutter application.
 
-# The following line prevents the package from being accidentally published to
-# pub.dev using `pub publish`. This is preferred for private packages.
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
-
-# The following defines the version and build number for your application.
-# A version number is three numbers separated by dots, like 1.2.43
-# followed by an optional build number separated by a +.
-# Both the version and the builder number may be overridden in flutter
-# build by specifying --build-name and --build-number, respectively.
-# In Android, build-name is used as versionName while build-number used as versionCode.
-# Read more about Android versioning at https://developer.android.com/studio/publish/versioning
-# In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
-# Read more about iOS versioning at
-# https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 version: 1.0.0+1
 
 environment:
@@ -24,9 +11,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.3
 
   # for firestore
@@ -46,39 +30,5 @@ dev_dependencies:
   build_runner:
   freezed:
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter.
 flutter:
-  # The following line ensures that the Material Icons font is
-  # included with your application, so that you can use the icons in
-  # the material Icons class.
   uses-material-design: true
-  # To add assets to your application, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-  # For details regarding adding assets from package dependencies, see
-  # https://flutter.dev/assets-and-images/#from-packages
-  # To add custom fonts to your application, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts from package dependencies,
-  # see https://flutter.dev/custom-fonts/#from-packages

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,13 @@ dependencies:
 
   table_calendar: ^2.2.3
 
+  # state
+  state_notifier: ^0.5.0
+  flutter_state_notifier: ^0.4.2
+  freezed_annotation:
+  provider: ^4.3.0
+
+  intl: ^0.16.1
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## 対応するissue
- close #31 

## 概要
CalendarPageにごちゃごちゃ書いてたのでリファクタした
完全にStateless化しようと思ったけど，TableCalendarに使っているanimationControllerを使うためにStatefulWidgetにする必要があったので完全にはできなかった

## 変更点・追加点
- CalendarPageにfreezed，StateNotifier，Providerを導入した
- Widgetを切り出した
- カレンダーに保存していたデータをStringからUserを使うようにした
カレンダーの下の日付表示しているところを曜日も出るようにした
## 使い方/バグ再現手順
- CalendarPageを開いて前回と同じ挙動をすることを確かめる
- 
- 
## スクリーンショット等
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## コードレビューチェックリスト
- [ ] 仕様と実装はあっている
- [ ] 無意味なロジックがない
- [ ] DRYを守っている
- [ ] テストが適切に書かれている
- [ ] メソッド名、変数名などが適切
- [ ] コーディングルールを守れている
- [ ] メソッドからは予想できない副作用が含まれていない

チェックした人：
## その他特記事項
