### PR TITLE
Usersモデルについてのセキュリティルールの追加

### DIFF
--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -1,16 +1,31 @@
 rules_version = '2';
 service cloud.firestore {
-  match /databases/{database}/documents {
+  function isAuthUser(auth, userId){
+    return auth != null && auth.uid == userId
+  }
 
-    // This rule allows anyone on the internet to view, edit, and delete
-    // all data in your Firestore database. It is useful for getting
-    // started, but it is configured to expire after 30 days because it
-    // leaves your app open to attackers. At that time, all client
-    // requests to your Firestore database will be denied.
-    //
-    // Make sure to write security rules for your app before that time, or else
-    // your app will lose access to your Firestore database
-    match /{document=**} {
+  function isValidUserSchema(user){
+    return user.size() == 6
+      && 'id' in user && user.id is string && user.id == request.auth.uid
+      && 'email' in user && user.email is string
+      && 'icon_url' in user && user.icon_url is string
+      && 'name' in user && user.name is string
+      && 'role' in user && user.role is string
+      && 'level' in user && user.level is string
+  }
+
+  function isValidUser(user){
+    return isValidUserSchema(user)
+  }
+
+  match /databases/{database}/documents {
+    match /users/{uid} {
+      allow read: if isAuthUser(request.auth, uid);
+      allow create, update: if isAuthUser(request.auth, uid) && isValidUser(request.resource.data);
+      allow delete: if isAuthUser(request.auth, uid);
+    }
+
+    match /organizations/{document=**} {
       allow read, write: if request.time < timestamp.date(2020, 7, 30);
     }
   }

--- a/firebase/tests/firestore.test.ts
+++ b/firebase/tests/firestore.test.ts
@@ -16,7 +16,7 @@ const createAdminApp = (): firebase.firestore.Firestore => {
 };
 
 // user情報への参照を作る
-const usersRef = (db: firebase.firestore.Firestore) => db.collection('user');
+const usersRef = (db: firebase.firestore.Firestore) => db.collection('users');
 
 describe('Firestoreセキュリティルール', () => {
   // ルールファイルの読み込み
@@ -35,10 +35,90 @@ describe('Firestoreセキュリティルール', () => {
     await Promise.all(firebase.apps().map(app => app.delete()));
   });
 
-  test('読み書きが可能', async () => {
-    const db = createAuthApp({uid: 'test'});
-    const user = usersRef(db).doc('test');
-    await firebase.assertSucceeds(user.set({name: '太郎'}));
-    await firebase.assertSucceeds(user.get());
+  const collectUser = {
+    id: 'test',
+    email: 'test@example.com',
+    icon_url: 'https://example.com/example.png',
+    name: 'テスト太郎',
+    role: 'アルバイト',
+    level: '100'
+  };
+
+  describe('ユーザ認証情報の検証', () => {
+    test(
+        '自分のuidと同様のドキュメントIDのユーザ情報だけを閲覧，作成，編集，削除可能',
+        async () => {
+          const db = createAuthApp({uid: collectUser.id});
+          const userDocumentRef = usersRef(db).doc(collectUser.id);
+
+          await firebase.assertSucceeds(userDocumentRef.set(collectUser));
+          await firebase.assertSucceeds(userDocumentRef.get());
+
+          await firebase.assertSucceeds(
+              userDocumentRef.update({name: '更新し太郎'}));
+
+          await firebase.assertSucceeds(userDocumentRef.delete());
+        });
+    test(
+        '自分のuidと異なるドキュメントは閲覧，作成，編集，削除ができない',
+        async () => {
+          usersRef(createAdminApp()).doc(collectUser.id).set(collectUser);
+          const db = createAuthApp({uid: 'invalid_user'});
+
+          const userDocumentRef = usersRef(db).doc(collectUser.id);
+
+          await firebase.assertFails(userDocumentRef.set(collectUser));
+
+          await firebase.assertFails(userDocumentRef.get());
+
+          await firebase.assertFails(
+              userDocumentRef.update({name: '更新し太郎'}));
+
+          await firebase.assertFails(userDocumentRef.delete());
+        })
+  });
+
+  describe('user スキーマの検証', () => {
+    test('正しくないスキーマの場合は作成できない', async () => {
+      const db = createAuthApp({uid: collectUser.id});
+      const userDocumentRef = usersRef(db).doc(collectUser.id);
+
+      await firebase.assertFails(
+          userDocumentRef.set({...collectUser, place: 'japan'}));
+
+      await firebase.assertFails(
+          userDocumentRef.set({...collectUser, id: 1234}));
+      await firebase.assertFails(
+          userDocumentRef.set({...collectUser, name: 1234}));
+      await firebase.assertFails(
+          userDocumentRef.set({...collectUser, email: 1234}));
+      await firebase.assertFails(
+          userDocumentRef.set({...collectUser, icon_url: 1234}));
+      await firebase.assertFails(
+          userDocumentRef.set({...collectUser, role: 1234}));
+      await firebase.assertFails(
+          userDocumentRef.set({...collectUser, level: 1234}));
+    });
+    test('正しくないスキーマの場合は編集できない', async () => {
+      usersRef(createAdminApp()).doc(collectUser.id).set(collectUser);
+      const db = createAuthApp({uid: collectUser.id});
+      const userDocumentRef = usersRef(db).doc(collectUser.id);
+
+      await firebase.assertFails(
+          userDocumentRef.update({...collectUser, place: 'japan'}));
+
+      await firebase.assertFails(
+          userDocumentRef.update({...collectUser, id: 1234}));
+      await firebase.assertFails(
+          userDocumentRef.update({...collectUser, name: 1234}));
+      await firebase.assertFails(
+          userDocumentRef.update({...collectUser, email: 1234}));
+      await firebase.assertFails(
+          userDocumentRef.update({...collectUser, icon_url: 1234}));
+      await firebase.assertFails(
+          userDocumentRef.update({...collectUser, role: 1234}));
+      await firebase.assertFails(
+          userDocumentRef.update({...collectUser, level: 1234}));
+    });
   });
 });


### PR DESCRIPTION
## 対応するissue
- なし
- 
## 概要
userデータのバリデーション，書き込み権限などのセキュリティルールの追加
organizations以下については，一時的に制限なく書き込めるようにした．
TODO:本来は，プルリクが通ったあとにfirestoreにルールの適用をするべきだが，動作確認のために，すでにデプロイ済みでし
## 変更点・追加点
- セキュリティルールのテストを記載した．
- Userのデータが設計したもの通りではないものが来たら弾く
- UserのログインIDと登録IDが違うものは，書き込みできないように弾く
- 以上のセキュリティルールを保証するテストを作成
## 使い方/バグ再現手順
- cd firebase
- docker-compose up -d
- npm test
- でうまくテストが通るとOK
## スクリーンショット等
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## コードレビューチェックリスト
- [ ] 仕様と実装はあっている
- [ ] 無意味なロジックがない
- [ ] DRYを守っている
- [ ] テストが適切に書かれている
- [ ] メソッド名、変数名などが適切
- [ ] コーディングルールを守れている
- [ ] メソッドからは予想できない副作用が含まれていない

チェックした人：
## その他特記事項
