### PR TITLE
feat: ShiftとShiftsRequestの操作を切り替えるための追加

### DIFF
--- a/lib/debug_views/debug_page.dart
+++ b/lib/debug_views/debug_page.dart
@@ -4,6 +4,7 @@ import 'package:shiftend/debug_views/shift_dialog.dart';
 import 'package:shiftend/debug_views/user_dialog.dart';
 
 import 'organization_dialog.dart';
+import 'shift_request_dialog.dart';
 
 class DebugPage extends StatelessWidget {
   @override
@@ -12,86 +13,116 @@ class DebugPage extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Debug Page'),
       ),
-      body: Column(
-        children: <Widget>[
-          FlatButton(
-            child: const Text('user load'),
-            onPressed: () {
-              print('pressed user load');
-              UserDialog.getUser(context);
-            },
-          ),
-          FlatButton(
-            child: const Text('user login'),
-            onPressed: () {
-              print('pressed user login');
-              UserDialog.showLoginDialog(context);
-            },
-          ),
-          FlatButton(
-            child: const Text('user update'),
-            onPressed: () {
-              print('pressed user update');
-              UserDialog.showUpdateDialog(context);
-            },
-          ),
-          FlatButton(
-            child: const Text('organization create'),
-            onPressed: () {
-              print('pressed organization create');
-              OrganizationDialog.showOrgCreateDialog(context);
-            },
-          ),
-          FlatButton(
-            child: const Text('organization get'),
-            onPressed: () {
-              print('pressed organization get');
-              OrganizationDialog.showOrgGetDialog(context);
-            },
-          ),
-          FlatButton(
-            child: const Text('organizations get'),
-            onPressed: () {
-              print('pressed organizations get');
-              OrganizationDialog.showOrgsGetDialog(context);
-            },
-          ),
-          FlatButton(
-            child: const Text('organizations update(定休日の追加)'),
-            onPressed: () {
-              print('pressed organizations update');
-              OrganizationDialog.showOrgUpdateDialog(context);
-            },
-          ),
-          FlatButton(
-            child: const Text('shift create'),
-            onPressed: () {
-              print('pressed shift create');
-              ShiftDialog.showShiftCreateDialog(context);
-            },
-          ),
-          FlatButton(
-            child: const Text('shift update'),
-            onPressed: () {
-              print('pressed shift update');
-              ShiftDialog.showShiftUpdateDialog(context);
-            },
-          ),
-          FlatButton(
-            child: const Text('shift delete'),
-            onPressed: () {
-              print('pressed shift delete');
-              ShiftDialog.showShiftDeleteDialog(context);
-            },
-          ),
-          FlatButton(
-            child: const Text('shift list get'),
-            onPressed: () {
-              print('pressed shift list get');
-              ShiftDialog.showShiftListGetDialog(context);
-            },
-          ),
-        ],
+      body: SingleChildScrollView(
+        child: Column(
+          children: <Widget>[
+            FlatButton(
+              child: const Text('user load'),
+              onPressed: () {
+                print('pressed user load');
+                UserDialog.getUser(context);
+              },
+            ),
+            FlatButton(
+              child: const Text('user login'),
+              onPressed: () {
+                print('pressed user login');
+                UserDialog.showLoginDialog(context);
+              },
+            ),
+            FlatButton(
+              child: const Text('user update'),
+              onPressed: () {
+                print('pressed user update');
+                UserDialog.showUpdateDialog(context);
+              },
+            ),
+            FlatButton(
+              child: const Text('organization create'),
+              onPressed: () {
+                print('pressed organization create');
+                OrganizationDialog.showOrgCreateDialog(context);
+              },
+            ),
+            FlatButton(
+              child: const Text('organization get'),
+              onPressed: () {
+                print('pressed organization get');
+                OrganizationDialog.showOrgGetDialog(context);
+              },
+            ),
+            FlatButton(
+              child: const Text('organizations get'),
+              onPressed: () {
+                print('pressed organizations get');
+                OrganizationDialog.showOrgsGetDialog(context);
+              },
+            ),
+            FlatButton(
+              child: const Text('organizations update(定休日の追加)'),
+              onPressed: () {
+                print('pressed organizations update');
+                OrganizationDialog.showOrgUpdateDialog(context);
+              },
+            ),
+            FlatButton(
+              child: const Text('shift create'),
+              onPressed: () {
+                print('pressed shift create');
+                ShiftDialog.showShiftCreateDialog(context);
+              },
+            ),
+            FlatButton(
+              child: const Text('shift update'),
+              onPressed: () {
+                print('pressed shift update');
+                ShiftDialog.showShiftUpdateDialog(context);
+              },
+            ),
+            FlatButton(
+              child: const Text('shift delete'),
+              onPressed: () {
+                print('pressed shift delete');
+                ShiftDialog.showShiftDeleteDialog(context);
+              },
+            ),
+            FlatButton(
+              child: const Text('shift list get'),
+              onPressed: () {
+                print('pressed shift list get');
+                ShiftDialog.showShiftListGetDialog(context);
+              },
+            ),
+            FlatButton(
+              child: const Text('shift request create'),
+              onPressed: () {
+                print('pressed shift request create');
+                ShiftRequestDialog.showShiftCreateDialog(context);
+              },
+            ),
+            FlatButton(
+              child: const Text('shift request update'),
+              onPressed: () {
+                print('pressed shift request update');
+                ShiftRequestDialog.showShiftUpdateDialog(context);
+              },
+            ),
+            FlatButton(
+              child: const Text('shift request delete'),
+              onPressed: () {
+                print('pressed shift delete');
+                ShiftRequestDialog.showShiftDeleteDialog(context);
+              },
+            ),
+            FlatButton(
+              child: const Text('shift request list get'),
+              onPressed: () {
+                print('pressed shift request list get');
+                ShiftRequestDialog.showShiftListGetDialog(context);
+              },
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/debug_views/globals.dart
+++ b/lib/debug_views/globals.dart
@@ -13,5 +13,9 @@ final UserRepository userRepo =
     UserRepository(auth: auth, firestore: Firestore.instance);
 final OrganizationRepository orgRepo =
     OrganizationRepository(firestore: Firestore.instance);
-final ShiftRepository shiftRepo =
-    ShiftRepository(firestore: Firestore.instance);
+final ShiftRepository shiftRepo = ShiftRepository(
+    firestore: Firestore.instance,
+    collectionName: ShiftRepository.SHIFTS_COLLECTION);
+final ShiftRepository shiftReqRepo = ShiftRepository(
+    firestore: Firestore.instance,
+    collectionName: ShiftRepository.SHIFTS_REQUEST_COLLECTION);

--- a/lib/debug_views/shift_request_dialog.dart
+++ b/lib/debug_views/shift_request_dialog.dart
@@ -1,0 +1,356 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:shiftend/models/models.dart';
+
+import 'globals.dart';
+
+class ShiftRequestDialog {
+  static void showShiftCreateDialog(BuildContext context) {
+    final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+    String orgId;
+    Shift shift = const Shift();
+    showDialog<dynamic>(
+      context: context,
+      builder: (BuildContext context) => AlertDialog(
+        title: const Text('シフト作成ダイアログ'),
+        content: Form(
+          key: _formKey,
+          child: Column(
+            children: <Widget>[
+              TextFormField(
+                decoration: const InputDecoration(
+                  icon: Icon(Icons.mail),
+                  labelText: 'Organization id',
+                ),
+                onSaved: (String value) {
+                  orgId = value;
+                },
+                validator: (value) {
+                  if (value.isEmpty) {
+                    return 'IDは必須入力項目です．';
+                  }
+                  return null;
+                },
+              ),
+              TextFormField(
+                decoration: const InputDecoration(
+                  icon: Icon(Icons.mail),
+                  labelText: 'User id',
+                ),
+                onSaved: (String value) {
+                  shift = shift.copyWith(userId: value);
+                },
+                validator: (value) {
+                  if (value.isEmpty) {
+                    return 'IDは必須入力項目です．';
+                  }
+                  return null;
+                },
+              ),
+              TextFormField(
+                decoration: const InputDecoration(
+                  icon: Icon(Icons.mail),
+                  labelText: 'Start Time',
+                ),
+                onSaved: (String value) {
+                  final DateTime start = DateTime.parse(value);
+                  shift = shift.copyWith(start: start);
+                },
+                validator: (value) {
+                  if (value.isEmpty) {
+                    return 'IDは必須入力項目です．';
+                  }
+                  return null;
+                },
+              ),
+              TextFormField(
+                decoration: const InputDecoration(
+                  icon: Icon(Icons.mail),
+                  labelText: 'End Time',
+                ),
+                onSaved: (String value) {
+                  final DateTime end = DateTime.parse(value);
+                  shift = shift.copyWith(end: end);
+                },
+                validator: (value) {
+                  if (value.isEmpty) {
+                    return 'IDは必須入力項目です．';
+                  }
+                  return null;
+                },
+              ),
+            ],
+          ),
+        ),
+        actions: <Widget>[
+          FlatButton(
+            child: const Text('キャンセル'),
+            onPressed: () {
+              Navigator.pop(context);
+            },
+          ),
+          FlatButton(
+            child: const Text('作成'),
+            onPressed: () {
+              if (_formKey.currentState.validate()) {
+                _formKey.currentState.save();
+                shiftReqRepo.create(orgId, shift);
+                Navigator.pop(context);
+              }
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  static void showShiftUpdateDialog(BuildContext context) {
+    final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+    String orgId;
+    Shift shift = const Shift();
+    showDialog<dynamic>(
+      context: context,
+      builder: (BuildContext context) => AlertDialog(
+        title: const Text('シフト更新ダイアログ'),
+        content: Form(
+          key: _formKey,
+          child: Column(
+            children: <Widget>[
+              TextFormField(
+                decoration: const InputDecoration(
+                  icon: Icon(Icons.mail),
+                  labelText: 'Organization id',
+                ),
+                onSaved: (String value) {
+                  orgId = value;
+                },
+                validator: (value) {
+                  if (value.isEmpty) {
+                    return 'IDは必須入力項目です．';
+                  }
+                  return null;
+                },
+              ),
+              TextFormField(
+                decoration: const InputDecoration(
+                  icon: Icon(Icons.mail),
+                  labelText: 'User id',
+                ),
+                onSaved: (String value) {
+                  shift = shift.copyWith(userId: value);
+                },
+                validator: (value) {
+                  if (value.isEmpty) {
+                    return 'IDは必須入力項目です．';
+                  }
+                  return null;
+                },
+              ),
+              TextFormField(
+                decoration: const InputDecoration(
+                  icon: Icon(Icons.mail),
+                  labelText: 'Start Time',
+                ),
+                onSaved: (String value) {
+                  final DateTime start = DateTime.parse(value);
+                  shift = shift.copyWith(start: start);
+                },
+                validator: (value) {
+                  if (value.isEmpty) {
+                    return 'IDは必須入力項目です．';
+                  }
+                  return null;
+                },
+              ),
+              TextFormField(
+                decoration: const InputDecoration(
+                  icon: Icon(Icons.mail),
+                  labelText: 'End Time',
+                ),
+                onSaved: (String value) {
+                  final DateTime end = DateTime.parse(value);
+                  shift = shift.copyWith(end: end);
+                },
+                validator: (value) {
+                  if (value.isEmpty) {
+                    return 'IDは必須入力項目です．';
+                  }
+                  return null;
+                },
+              ),
+            ],
+          ),
+        ),
+        actions: <Widget>[
+          FlatButton(
+            child: const Text('キャンセル'),
+            onPressed: () {
+              Navigator.pop(context);
+            },
+          ),
+          FlatButton(
+            child: const Text('更新'),
+            onPressed: () {
+              if (_formKey.currentState.validate()) {
+                _formKey.currentState.save();
+                shiftReqRepo.update(orgId, shift);
+                Navigator.pop(context);
+              }
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  static void showShiftDeleteDialog(BuildContext context) {
+    final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+    String orgId;
+    DateTime day;
+    String userId;
+    showDialog<dynamic>(
+      context: context,
+      builder: (BuildContext context) => AlertDialog(
+        title: const Text('シフト情報取得ダイアログ'),
+        content: Form(
+          key: _formKey,
+          child: Column(
+            children: <Widget>[
+              TextFormField(
+                decoration: const InputDecoration(
+                  icon: Icon(Icons.mail),
+                  labelText: 'Organization id',
+                ),
+                onSaved: (String value) {
+                  orgId = value;
+                },
+                validator: (value) {
+                  if (value.isEmpty) {
+                    return 'IDは必須入力項目です．';
+                  }
+                  return null;
+                },
+              ),
+              TextFormField(
+                decoration: const InputDecoration(
+                  icon: Icon(Icons.mail),
+                  labelText: 'user id',
+                ),
+                onSaved: (String value) {
+                  userId = value;
+                },
+                validator: (value) {
+                  if (value.isEmpty) {
+                    return 'IDは必須入力項目です．';
+                  }
+                  return null;
+                },
+              ),
+              TextFormField(
+                decoration: const InputDecoration(
+                  icon: Icon(Icons.mail),
+                  labelText: 'Day',
+                ),
+                onSaved: (String value) {
+                  day = DateTime.parse(value);
+                },
+                validator: (value) {
+                  if (value.isEmpty) {
+                    return 'IDは必須入力項目です．';
+                  }
+                  return null;
+                },
+              )
+            ],
+          ),
+        ),
+        actions: <Widget>[
+          FlatButton(
+            child: const Text('キャンセル'),
+            onPressed: () {
+              Navigator.pop(context);
+            },
+          ),
+          FlatButton(
+            child: const Text('削除'),
+            onPressed: () {
+              if (_formKey.currentState.validate()) {
+                _formKey.currentState.save();
+                shiftReqRepo.delete(orgId, day, userId);
+                Navigator.pop(context);
+              }
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  static void showShiftListGetDialog(BuildContext context) {
+    final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+    String orgId;
+    DateTime month;
+    showDialog<dynamic>(
+      context: context,
+      builder: (BuildContext context) => AlertDialog(
+        title: const Text('シフト情報取得ダイアログ'),
+        content: Form(
+          key: _formKey,
+          child: Column(
+            children: <Widget>[
+              TextFormField(
+                decoration: const InputDecoration(
+                  icon: Icon(Icons.mail),
+                  labelText: 'Organization id',
+                ),
+                onSaved: (String value) {
+                  orgId = value;
+                },
+                validator: (value) {
+                  if (value.isEmpty) {
+                    return 'IDは必須入力項目です．';
+                  }
+                  return null;
+                },
+              ),
+              TextFormField(
+                decoration: const InputDecoration(
+                  icon: Icon(Icons.mail),
+                  labelText: 'Month',
+                ),
+                onSaved: (String value) {
+                  month = DateTime.parse(value);
+                },
+                validator: (value) {
+                  if (value.isEmpty) {
+                    return 'IDは必須入力項目です．';
+                  }
+                  return null;
+                },
+              )
+            ],
+          ),
+        ),
+        actions: <Widget>[
+          FlatButton(
+            child: const Text('キャンセル'),
+            onPressed: () {
+              Navigator.pop(context);
+            },
+          ),
+          FlatButton(
+            child: const Text('取得'),
+            onPressed: () async {
+              if (_formKey.currentState.validate()) {
+                _formKey.currentState.save();
+                final shifts = await shiftReqRepo.getShifts(orgId, month);
+                print(shifts);
+                Navigator.pop(context);
+              }
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/repositories/shift_repository.dart
+++ b/lib/repositories/shift_repository.dart
@@ -6,11 +6,17 @@ import 'package:shiftend/models/shift/shift.dart';
 import 'package:shiftend/repositories/interfaces/shift_repository_interface.dart';
 
 class ShiftRepository extends ShiftRepositoryInterface {
-  ShiftRepository({@required this.firestore}) : assert(firestore != null);
+  ShiftRepository({@required this.firestore, @required this.collectionName})
+      : assert(firestore != null),
+        assert(collectionName == SHIFTS_COLLECTION ||
+            collectionName == SHIFTS_REQUEST_COLLECTION);
 
   final Firestore firestore;
-  static const String collectionName = 'organizations';
-  static const String shiftsCollectionName = 'shifts';
+  final String orgCollectionName = 'organizations';
+  final String collectionName;
+
+  static const String SHIFTS_COLLECTION = 'shifts';
+  static const String SHIFTS_REQUEST_COLLECTION = 'shift-requests';
 
   final DateFormat formatter = DateFormat('yyyy-MM');
 
@@ -60,9 +66,9 @@ class ShiftRepository extends ShiftRepositoryInterface {
     final ym = DateTime(year, month);
     final ym_str = formatter.format(ym);
     return firestore
-        .collection(collectionName)
+        .collection(orgCollectionName)
         .document(orgId)
-        .collection(shiftsCollectionName)
+        .collection(collectionName)
         .document(ym_str);
   }
 


### PR DESCRIPTION
## 対応するissue
- close #14 
- 
## 概要
シフト希望もオーナが作るシフトと同じデータ構造，操作で良いと判断したため，
ShiftRepositoryの引数にcollectionNameを与えて，shiftsかshift-requestsコレクションを切り替えるように実装を行った．

## 変更点・追加点
- ShiftReposiotryの引数にcollectionNameを必須引数として追加した．
- 使うべきcollectionNameは，ShiftRepositoryのSHIFTS_COLLECTIONとSHIFTS_REQUEST_COLLECTIONで定義
- 
## 使い方/バグ再現手順
- debugページでシフト情報と同じようにcreateなどができるか確認，そのデータが，shift-requestsに貯められているかどうか確認
- 
- 
## スクリーンショット等
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## コードレビューチェックリスト
- [ ] 仕様と実装はあっている
- [ ] 無意味なロジックがない
- [ ] DRYを守っている
- [ ] テストが適切に書かれている
- [ ] メソッド名、変数名などが適切
- [ ] コーディングルールを守れている
- [ ] メソッドからは予想できない副作用が含まれていない

チェックした人：
## その他特記事項
