### PR TITLE
シフト情報をFireStoreから取ってきてカレンダーに表示するようにした

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,13 +1,16 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_state_notifier/flutter_state_notifier.dart';
 import 'package:intl/date_symbol_data_local.dart';
 import 'package:provider/provider.dart';
 import 'package:shiftend/debug_views/debug_page.dart';
-import 'package:shiftend/pages/calendar/calendar_state_controller.dart';
-import 'package:shiftend/pages/calendar/calendar_state.dart';
 import 'package:shiftend/member_page.dart';
 import 'package:shiftend/pages/calendar/calendar_page.dart';
+import 'package:shiftend/pages/calendar/calendar_state.dart';
+import 'package:shiftend/pages/calendar/calendar_state_controller.dart';
 import 'package:shiftend/pages/setting/setting_page.dart';
+import 'package:shiftend/repositories/mocks/shift_repository_mock.dart';
+import 'package:shiftend/repositories/shift_repository.dart';
 
 void main() {
   initializeDateFormatting().then((value) => runApp(MyApp()));
@@ -16,13 +19,23 @@ void main() {
 class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'Shiftend',
-      theme: ThemeData(
-        primarySwatch: Colors.blue,
-        visualDensity: VisualDensity.adaptivePlatformDensity,
+    return MultiProvider(
+      providers: [
+        Provider<ShiftRepository>.value(
+          value: ShiftRepository(firestore: Firestore.instance),
+        ),
+        Provider<ShiftRepositoryMock>.value(
+          value: ShiftRepositoryMock(),
+        ),
+      ],
+      child: MaterialApp(
+        title: 'Shiftend',
+        theme: ThemeData(
+          primarySwatch: Colors.blue,
+          visualDensity: VisualDensity.adaptivePlatformDensity,
+        ),
+        home: Main(),
       ),
-      home: Main(),
     );
   }
 }
@@ -46,8 +59,8 @@ class _MainState extends State<Main> {
     return MultiProvider(
       providers: [
         StateNotifierProvider<CalendarStateController, CalendarState>(
-          create: (_) => CalendarStateController(),
-        )
+          create: (context) => CalendarStateController(),
+        ),
       ],
       child: Scaffold(
         body: _pages[_currentIndex],

--- a/lib/models/notifier_state.dart
+++ b/lib/models/notifier_state.dart
@@ -1,0 +1,5 @@
+enum NotifierState {
+  initial,
+  loading,
+  loaded,
+}

--- a/lib/pages/calendar/calendar_page.dart
+++ b/lib/pages/calendar/calendar_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:shiftend/models/notifier_state.dart';
 import 'package:shiftend/pages/calendar/calendar_state.dart';
 import 'package:shiftend/pages/calendar/widgets/calendar_list_widget.dart';
 import 'package:shiftend/pages/calendar/widgets/calendar_widget.dart';
@@ -37,33 +38,40 @@ class _CalendarPageState extends State<CalendarPage>
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: SafeArea(
-        child: Column(
-          mainAxisSize: MainAxisSize.max,
-          children: <Widget>[
-            CalendarWidget(
-              calendarController: _calendarController,
-              animationController: _animationController,
-            ),
-            ConstrainedBox(
-              constraints: const BoxConstraints.expand(height: 20),
-              child: Container(
-                color: Colors.grey[300],
-                child: Text(fullDateToJa(
-                    Provider.of<CalendarState>(context, listen: true)
-                        .selectedDate)),
+    if (Provider.of<CalendarState>(context, listen: true).notifierState ==
+        NotifierState.loaded) {
+      return Scaffold(
+        body: SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.max,
+            children: <Widget>[
+              CalendarWidget(
+                calendarController: _calendarController,
+                animationController: _animationController,
               ),
-            ),
-            Expanded(
-              child: CalendarListWidget(
-                attendees:
-                    Provider.of<CalendarState>(context).selectedAttendees,
+              ConstrainedBox(
+                constraints: const BoxConstraints.expand(height: 20),
+                child: Container(
+                  color: Colors.grey[300],
+                  child: Text(fullDateToJa(
+                      Provider.of<CalendarState>(context, listen: true)
+                          .selectedDate)),
+                ),
               ),
-            ),
-          ],
+              Expanded(
+                child: CalendarListWidget(
+                  shifts: Provider.of<CalendarState>(context, listen: true)
+                      .selectedShifts,
+                ),
+              ),
+            ],
+          ),
         ),
-      ),
-    );
+      );
+    } else {
+      return const Center(
+        child: CircularProgressIndicator(),
+      );
+    }
   }
 }

--- a/lib/pages/calendar/calendar_state.dart
+++ b/lib/pages/calendar/calendar_state.dart
@@ -1,13 +1,15 @@
 import 'package:freezed_annotation/freezed_annotation.dart';
 import 'package:shiftend/models/models.dart';
+import 'package:shiftend/models/notifier_state.dart';
 
 part 'calendar_state.freezed.dart';
 
 @freezed
 abstract class CalendarState with _$CalendarState {
   const factory CalendarState({
-    Map<DateTime, List<User>> attendees,
+    @Default(NotifierState.initial) NotifierState notifierState,
+    Map<DateTime, List<Shift>> shifts,
     DateTime selectedDate,
-    List<User> selectedAttendees,
+    List<Shift> selectedShifts,
   }) = _CalendarState;
 }

--- a/lib/pages/calendar/calendar_state.freezed.dart
+++ b/lib/pages/calendar/calendar_state.freezed.dart
@@ -13,13 +13,15 @@ class _$CalendarStateTearOff {
   const _$CalendarStateTearOff();
 
   _CalendarState call(
-      {Map<DateTime, List<User>> attendees,
+      {NotifierState notifierState = NotifierState.initial,
+      Map<DateTime, List<Shift>> shifts,
       DateTime selectedDate,
-      List<User> selectedAttendees}) {
+      List<Shift> selectedShifts}) {
     return _CalendarState(
-      attendees: attendees,
+      notifierState: notifierState,
+      shifts: shifts,
       selectedDate: selectedDate,
-      selectedAttendees: selectedAttendees,
+      selectedShifts: selectedShifts,
     );
   }
 }
@@ -28,9 +30,10 @@ class _$CalendarStateTearOff {
 const $CalendarState = _$CalendarStateTearOff();
 
 mixin _$CalendarState {
-  Map<DateTime, List<User>> get attendees;
+  NotifierState get notifierState;
+  Map<DateTime, List<Shift>> get shifts;
   DateTime get selectedDate;
-  List<User> get selectedAttendees;
+  List<Shift> get selectedShifts;
 
   $CalendarStateCopyWith<CalendarState> get copyWith;
 }
@@ -40,9 +43,10 @@ abstract class $CalendarStateCopyWith<$Res> {
           CalendarState value, $Res Function(CalendarState) then) =
       _$CalendarStateCopyWithImpl<$Res>;
   $Res call(
-      {Map<DateTime, List<User>> attendees,
+      {NotifierState notifierState,
+      Map<DateTime, List<Shift>> shifts,
       DateTime selectedDate,
-      List<User> selectedAttendees});
+      List<Shift> selectedShifts});
 }
 
 class _$CalendarStateCopyWithImpl<$Res>
@@ -55,20 +59,24 @@ class _$CalendarStateCopyWithImpl<$Res>
 
   @override
   $Res call({
-    Object attendees = freezed,
+    Object notifierState = freezed,
+    Object shifts = freezed,
     Object selectedDate = freezed,
-    Object selectedAttendees = freezed,
+    Object selectedShifts = freezed,
   }) {
     return _then(_value.copyWith(
-      attendees: attendees == freezed
-          ? _value.attendees
-          : attendees as Map<DateTime, List<User>>,
+      notifierState: notifierState == freezed
+          ? _value.notifierState
+          : notifierState as NotifierState,
+      shifts: shifts == freezed
+          ? _value.shifts
+          : shifts as Map<DateTime, List<Shift>>,
       selectedDate: selectedDate == freezed
           ? _value.selectedDate
           : selectedDate as DateTime,
-      selectedAttendees: selectedAttendees == freezed
-          ? _value.selectedAttendees
-          : selectedAttendees as List<User>,
+      selectedShifts: selectedShifts == freezed
+          ? _value.selectedShifts
+          : selectedShifts as List<Shift>,
     ));
   }
 }
@@ -80,9 +88,10 @@ abstract class _$CalendarStateCopyWith<$Res>
       __$CalendarStateCopyWithImpl<$Res>;
   @override
   $Res call(
-      {Map<DateTime, List<User>> attendees,
+      {NotifierState notifierState,
+      Map<DateTime, List<Shift>> shifts,
       DateTime selectedDate,
-      List<User> selectedAttendees});
+      List<Shift> selectedShifts});
 }
 
 class __$CalendarStateCopyWithImpl<$Res>
@@ -97,61 +106,75 @@ class __$CalendarStateCopyWithImpl<$Res>
 
   @override
   $Res call({
-    Object attendees = freezed,
+    Object notifierState = freezed,
+    Object shifts = freezed,
     Object selectedDate = freezed,
-    Object selectedAttendees = freezed,
+    Object selectedShifts = freezed,
   }) {
     return _then(_CalendarState(
-      attendees: attendees == freezed
-          ? _value.attendees
-          : attendees as Map<DateTime, List<User>>,
+      notifierState: notifierState == freezed
+          ? _value.notifierState
+          : notifierState as NotifierState,
+      shifts: shifts == freezed
+          ? _value.shifts
+          : shifts as Map<DateTime, List<Shift>>,
       selectedDate: selectedDate == freezed
           ? _value.selectedDate
           : selectedDate as DateTime,
-      selectedAttendees: selectedAttendees == freezed
-          ? _value.selectedAttendees
-          : selectedAttendees as List<User>,
+      selectedShifts: selectedShifts == freezed
+          ? _value.selectedShifts
+          : selectedShifts as List<Shift>,
     ));
   }
 }
 
 class _$_CalendarState implements _CalendarState {
   const _$_CalendarState(
-      {this.attendees, this.selectedDate, this.selectedAttendees});
+      {this.notifierState = NotifierState.initial,
+      this.shifts,
+      this.selectedDate,
+      this.selectedShifts})
+      : assert(notifierState != null);
 
+  @JsonKey(defaultValue: NotifierState.initial)
   @override
-  final Map<DateTime, List<User>> attendees;
+  final NotifierState notifierState;
+  @override
+  final Map<DateTime, List<Shift>> shifts;
   @override
   final DateTime selectedDate;
   @override
-  final List<User> selectedAttendees;
+  final List<Shift> selectedShifts;
 
   @override
   String toString() {
-    return 'CalendarState(attendees: $attendees, selectedDate: $selectedDate, selectedAttendees: $selectedAttendees)';
+    return 'CalendarState(notifierState: $notifierState, shifts: $shifts, selectedDate: $selectedDate, selectedShifts: $selectedShifts)';
   }
 
   @override
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other is _CalendarState &&
-            (identical(other.attendees, attendees) ||
+            (identical(other.notifierState, notifierState) ||
                 const DeepCollectionEquality()
-                    .equals(other.attendees, attendees)) &&
+                    .equals(other.notifierState, notifierState)) &&
+            (identical(other.shifts, shifts) ||
+                const DeepCollectionEquality().equals(other.shifts, shifts)) &&
             (identical(other.selectedDate, selectedDate) ||
                 const DeepCollectionEquality()
                     .equals(other.selectedDate, selectedDate)) &&
-            (identical(other.selectedAttendees, selectedAttendees) ||
+            (identical(other.selectedShifts, selectedShifts) ||
                 const DeepCollectionEquality()
-                    .equals(other.selectedAttendees, selectedAttendees)));
+                    .equals(other.selectedShifts, selectedShifts)));
   }
 
   @override
   int get hashCode =>
       runtimeType.hashCode ^
-      const DeepCollectionEquality().hash(attendees) ^
+      const DeepCollectionEquality().hash(notifierState) ^
+      const DeepCollectionEquality().hash(shifts) ^
       const DeepCollectionEquality().hash(selectedDate) ^
-      const DeepCollectionEquality().hash(selectedAttendees);
+      const DeepCollectionEquality().hash(selectedShifts);
 
   @override
   _$CalendarStateCopyWith<_CalendarState> get copyWith =>
@@ -160,16 +183,19 @@ class _$_CalendarState implements _CalendarState {
 
 abstract class _CalendarState implements CalendarState {
   const factory _CalendarState(
-      {Map<DateTime, List<User>> attendees,
+      {NotifierState notifierState,
+      Map<DateTime, List<Shift>> shifts,
       DateTime selectedDate,
-      List<User> selectedAttendees}) = _$_CalendarState;
+      List<Shift> selectedShifts}) = _$_CalendarState;
 
   @override
-  Map<DateTime, List<User>> get attendees;
+  NotifierState get notifierState;
+  @override
+  Map<DateTime, List<Shift>> get shifts;
   @override
   DateTime get selectedDate;
   @override
-  List<User> get selectedAttendees;
+  List<Shift> get selectedShifts;
   @override
   _$CalendarStateCopyWith<_CalendarState> get copyWith;
 }

--- a/lib/pages/calendar/widgets/calendar_list_widget.dart
+++ b/lib/pages/calendar/widgets/calendar_list_widget.dart
@@ -3,26 +3,26 @@ import 'package:flutter/material.dart';
 import 'package:shiftend/models/models.dart';
 
 class CalendarListWidget extends StatelessWidget {
-  const CalendarListWidget({this.attendees});
+  const CalendarListWidget({this.shifts});
 
-  final List<User> attendees;
+  final List<Shift> shifts;
 
   @override
   Widget build(BuildContext context) {
     Widget child = Container();
-    if (attendees != null) {
+    if (shifts != null) {
       child = ListView(
-        children: attendees
+        children: shifts
             .map(
-              (attendee) => Container(
+              (shift) => Container(
                 decoration: BoxDecoration(
                   border: Border.all(width: 0.8),
                   borderRadius: BorderRadius.circular(12),
                 ),
                 margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                 child: ListTile(
-                  title: Text(attendee.toString()),
-                  onTap: () => print('$attendee tapped'),
+                  title: Text(shift.toString()),
+                  onTap: () => print('$shift tapped'),
                 ),
               ),
             )

--- a/lib/pages/calendar/widgets/calendar_widget.dart
+++ b/lib/pages/calendar/widgets/calendar_widget.dart
@@ -20,13 +20,13 @@ class CalendarWidget extends StatelessWidget {
     return TableCalendar(
       locale: 'ja_JP',
       calendarController: calendarController,
-      events: Provider.of<CalendarState>(context, listen: true).attendees,
+      events: Provider.of<CalendarState>(context, listen: true).shifts,
       initialCalendarFormat: CalendarFormat.month,
       formatAnimation: FormatAnimation.slide,
       startingDayOfWeek: StartingDayOfWeek.sunday,
       availableGestures: AvailableGestures.horizontalSwipe,
       calendarStyle: CalendarStyle(
-        outsideDaysVisible: true,
+        outsideDaysVisible: false,
         outsideWeekendStyle: const TextStyle().copyWith(color: Colors.black),
         weekdayStyle: const TextStyle().copyWith(color: Colors.black),
         weekendStyle: const TextStyle().copyWith(color: Colors.black),
@@ -109,8 +109,12 @@ class CalendarWidget extends StatelessWidget {
       ),
       onDaySelected: (date, attendees) {
         Provider.of<CalendarStateController>(context, listen: false)
-            .onDaySelected(date, attendees.cast<User>());
+            .onDaySelected(date, attendees.cast<Shift>());
         animationController.forward(from: 0);
+      },
+      onVisibleDaysChanged: (first, last, format) {
+        Provider.of<CalendarStateController>(context, listen: false)
+            .fetchShiftsOfMonth(last);
       },
     );
   }

--- a/lib/repositories/mocks/shift_repository_mock.dart
+++ b/lib/repositories/mocks/shift_repository_mock.dart
@@ -14,7 +14,7 @@ class ShiftRepositoryMock extends ShiftRepositoryInterface {
           Shift(
               userId: '1',
               start: DateTime.parse('2020-07-03 17:00'),
-              end: DateTime.parse('2020-07-04 2:00')),
+              end: DateTime.parse('2020-07-04 02:00')),
         ],
         DateTime(2020, 7, 10): <Shift>[
           Shift(
@@ -24,7 +24,7 @@ class ShiftRepositoryMock extends ShiftRepositoryInterface {
           Shift(
               userId: '1',
               start: DateTime.parse('2020-07-10 17:00'),
-              end: DateTime.parse('2020-07-11 2:00')),
+              end: DateTime.parse('2020-07-11 02:00')),
         ],
         DateTime(2020, 7, 20): <Shift>[
           Shift(
@@ -34,11 +34,11 @@ class ShiftRepositoryMock extends ShiftRepositoryInterface {
           Shift(
               userId: '1',
               start: DateTime.parse('2020-07-20 17:00'),
-              end: DateTime.parse('2020-07-21 2:00')),
+              end: DateTime.parse('2020-07-21 02:00')),
           Shift(
               userId: '2',
               start: DateTime.parse('2020-07-20 18:00'),
-              end: DateTime.parse('2020-07-21 0:00')),
+              end: DateTime.parse('2020-07-21 00:00')),
         ],
         DateTime(2020, 7, 22): <Shift>[
           Shift(
@@ -48,7 +48,7 @@ class ShiftRepositoryMock extends ShiftRepositoryInterface {
           Shift(
               userId: '1',
               start: DateTime.parse('2020-07-22 17:00'),
-              end: DateTime.parse('2020-07-23 2:00')),
+              end: DateTime.parse('2020-07-23 02:00')),
         ],
       }
     }


### PR DESCRIPTION
## 対応するissue
- #22 

## 概要
タイトルの通り

## 変更点・追加点
-`main.dart` でRepositoryをMultiProviderで供給してそれ以下でどこでも使えるようにしている
- Repositoryにおいてるメソッドは基本StateNotifierを継承したクラスにLocatorMixinを使ってDIして呼び出してfreezedでつくったStateを更新する．
- 
## 使い方/バグ再現手順
- `CalendarStateController`の中のfetchShifts~~にprint文はさんで色々表示してみるとFireStoreからレスポンス返ってきてることが確認できる
## スクリーンショット等
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## コードレビューチェックリスト
- [ ] 仕様と実装はあっている
- [ ] 無意味なロジックがない
- [ ] DRYを守っている
- [ ] テストが適切に書かれている
- [ ] メソッド名、変数名などが適切
- [ ] コーディングルールを守れている
- [ ] メソッドからは予想できない副作用が含まれていない

チェックした人：
## その他特記事項
