### PR TITLE
[wip]組織のデータについてのセキュリティルール

### DIFF
--- a/firebase/tests/constant.ts
+++ b/firebase/tests/constant.ts
@@ -1,0 +1,38 @@
+import * as firebase from '@firebase/testing';
+import * as fs from 'fs';
+
+export const PROJECT_ID = 'shiftend-47fca';
+export const RULES_PATH = 'firestore.rules';
+
+// 認証付きのFreistore appを作成する
+export const createAuthApp = (auth?: object): firebase.firestore.Firestore => {
+  return firebase.initializeTestApp({projectId: PROJECT_ID, auth: auth})
+      .firestore();
+};
+
+// 管理者権限で操作できるFreistore appを作成する
+export const createAdminApp = (): firebase.firestore.Firestore => {
+  return firebase.initializeAdminApp({projectId: PROJECT_ID}).firestore();
+};
+
+export const loadRules = () =>　firebase.loadFirestoreRules(
+    {projectId: PROJECT_ID, rules: fs.readFileSync(RULES_PATH, 'utf8')});
+
+export const clearData = () =>
+    firebase.clearFirestoreData({projectId: PROJECT_ID});
+
+export const deleteApp = () =>
+    Promise.all(firebase.apps().map(app => app.delete()));
+
+// user情報への参照を作る
+export const usersRef = (db: firebase.firestore.Firestore) =>
+    db.collection('users');
+
+export const collectUser = {
+  id: 'test',
+  email: 'test@example.com',
+  icon_url: 'https://example.com/example.png',
+  name: 'テスト太郎',
+  role: 'アルバイト',
+  level: '100'
+};

--- a/firebase/tests/constant.ts
+++ b/firebase/tests/constant.ts
@@ -28,6 +28,9 @@ export const deleteApp = () =>
 export const usersRef = (db: firebase.firestore.Firestore) =>
     db.collection('users');
 
+export const orgsRef = (db: firebase.firestore.Firestore) =>
+    db.collection('organizations');
+
 export const collectUser = {
   id: 'test',
   email: 'test@example.com',
@@ -36,3 +39,42 @@ export const collectUser = {
   role: 'アルバイト',
   level: '100'
 };
+
+export const ownerUser = {
+  id: 'owner',
+  email: 'owner@example.com',
+  icon_url: 'https://example.com/owner.png',
+  name: 'テスト店長',
+  role: '店長',
+  level: '100'
+}
+
+export const memberUser = {
+  id: 'member',
+  email: 'member@example.com',
+  icon_url: 'https://example.com/member.png',
+  name: 'テストメンバー',
+  role: 'アルバイト',
+  level: '100'
+}
+
+export const collectOrganization = {
+  id: 'test_organization',
+  owner_ids: [
+    ownerUser.id,
+  ],
+  member_ids: [
+    ownerUser.id,
+    memberUser.id,
+  ],
+  default_holidays: [
+    {
+      day_of_week: 0,
+      n_week: 0,
+    },
+    {
+      day_of_week: 1,
+      n_week: 1,
+    },
+  ],
+}

--- a/firebase/tests/organization.test.ts
+++ b/firebase/tests/organization.test.ts
@@ -1,0 +1,249 @@
+import * as firebase from '@firebase/testing';
+
+import {clearData, collectOrganization, collectUser, createAdminApp, createAuthApp, deleteApp, loadRules, memberUser, orgsRef, ownerUser, usersRef} from './constant';
+
+describe('Organizationモデルについてのセキュリティルール', () => {
+  // ルールファイルの読み込み
+  beforeAll(async () => {await loadRules()});
+
+  // Firestoreデータのクリーンアップ
+  afterEach(async () => {await clearData()});
+
+  // Firestoreアプリの削除
+  afterAll(async () => {await deleteApp()});
+
+  describe('組織に対する権限の検証', () => {
+    test('認証ユーザであれば，組織を作成可能', async () => {
+      const db = createAuthApp({uid: collectUser.id});
+      const orgDocumentRef = orgsRef(db).doc(collectOrganization.id);
+
+      await firebase.assertSucceeds(orgDocumentRef.set(collectOrganization));
+    });
+    test('非認証ユーザは，組織を作成不可', async () => {
+      const db = createAuthApp();
+      const orgDocumentRef = orgsRef(db).doc(collectOrganization.id);
+      await firebase.assertFails(orgDocumentRef.set(collectOrganization));
+    })
+    test('オーナーである組織を，閲覧，編集，削除可能', async () => {
+      const db = createAuthApp({uid: collectUser.id});
+      const orgDocumentRef = orgsRef(db).doc(collectOrganization.id);
+      await orgDocumentRef.set(collectOrganization);
+
+      await firebase.assertSucceeds(orgDocumentRef.get());
+      await firebase.assertSucceeds(
+          orgDocumentRef.update({
+            members: [
+              collectUser.id,
+              'added_member',
+            ],
+          }),
+      );
+      await firebase.assertSucceeds(orgDocumentRef.delete());
+    });
+    test('メンバーである組織を閲覧可能', async () => {
+      const adminDb = createAdminApp();
+      await orgsRef(adminDb)
+          .doc(collectOrganization.id)
+          .set(collectOrganization);
+
+      const db = createAuthApp({uid: memberUser.id})
+      const orgDocumentRef = orgsRef(db).doc(collectOrganization.id);
+
+      await firebase.assertSucceeds(orgDocumentRef.get());
+    });
+    test('オーナーでないメンバーは組織を編集，削除できない', async () => {
+      const adminDb = createAdminApp();
+      await orgsRef(adminDb)
+          .doc(collectOrganization.id)
+          .set(collectOrganization);
+
+      const db = createAuthApp({uid: memberUser.id})
+      const orgDocumentRef = orgsRef(db).doc(collectOrganization.id);
+
+      await firebase.assertFails(
+          orgDocumentRef.update({
+            members: [
+              collectUser.id,
+              'added_member',
+            ],
+          }),
+      );
+      await firebase.assertFails(orgDocumentRef.delete());
+    });
+    test('メンバー外は組織を閲覧，編集，削除できない', async () => {
+      const adminDb = createAdminApp();
+      await orgsRef(adminDb)
+          .doc(collectOrganization.id)
+          .set(collectOrganization);
+
+      const db = createAuthApp({uid: collectUser.id})
+      const orgDocumentRef = orgsRef(db).doc(collectOrganization.id);
+
+      await firebase.assertFails(orgDocumentRef.get());
+      await firebase.assertFails(
+          orgDocumentRef.update({
+            members: [
+              collectUser.id,
+              'added_member',
+            ],
+          }),
+      );
+      await firebase.assertFails(orgDocumentRef.delete());
+    })
+  });
+
+  describe('組織スキーマの検証', () => {
+    test('正しくないスキーマの場合は作成できない', async () => {
+      const db = createAuthApp({uid: ownerUser.id});
+      const orgDocumentRef = orgsRef(db).doc(collectOrganization.id);
+
+      await firebase.assertFails(
+          orgDocumentRef.set({...collectOrganization, place: 'japan'}));
+      await firebase.assertFails(orgDocumentRef.set({
+        ...collectOrganization,
+        id: 1234,
+      }));
+      await firebase.assertFails(orgDocumentRef.set({
+        ...collectOrganization,
+        owner_ids: [],
+      }));
+      await firebase.assertFails(orgDocumentRef.set({
+        ...collectOrganization,
+        owner_ids: [
+          1,
+        ],
+      }));
+      await firebase.assertFails(orgDocumentRef.set({
+        ...collectOrganization,
+        member_ids: [],
+      }));
+      await firebase.assertFails(orgDocumentRef.set({
+        ...collectOrganization,
+        member_ids: [
+          1,
+        ]
+      }));
+      await firebase.assertFails(orgDocumentRef.set({
+        ...collectOrganization,
+        default_holidays: [
+          {
+            youbi: 0,
+            dainann: 0,
+          },
+        ]
+      }));
+      await firebase.assertFails(orgDocumentRef.set({
+        ...collectOrganization,
+        default_holidays: [
+          {
+            day_of_week: '火曜日',
+            n_week: '隔週',
+          },
+        ]
+      }));
+    });
+
+    test('正しくないスキーマの場合は編集できない', async () => {
+      const db = createAuthApp({uid: ownerUser.id});
+      const orgDocumentRef = orgsRef(db).doc(collectOrganization.id);
+
+      await firebase.assertFails(
+          orgDocumentRef.update({...collectOrganization, place: 'japan'}));
+      await firebase.assertFails(orgDocumentRef.update({
+        ...collectOrganization,
+        id: 1234,
+      }));
+      await firebase.assertFails(orgDocumentRef.update({
+        ...collectOrganization,
+        owner_ids: [],
+      }));
+      await firebase.assertFails(orgDocumentRef.update({
+        ...collectOrganization,
+        owner_ids: [
+          1,
+        ],
+      }));
+      await firebase.assertFails(orgDocumentRef.update({
+        ...collectOrganization,
+        member_ids: [],
+      }));
+      await firebase.assertFails(orgDocumentRef.update({
+        ...collectOrganization,
+        member_ids: [
+          1,
+        ]
+      }));
+      await firebase.assertFails(orgDocumentRef.update({
+        ...collectOrganization,
+        default_holidays: [
+          {
+            youbi: 0,
+            dainann: 0,
+          },
+        ]
+      }));
+      await firebase.assertFails(orgDocumentRef.update({
+        ...collectOrganization,
+        default_holidays: [
+          {
+            day_of_week: '火曜日',
+            n_week: '隔週',
+          },
+        ]
+      }));
+      await firebase.assertFails(orgDocumentRef.update({
+        ...collectOrganization,
+        default_holidays: [
+          {
+            day_of_week: 1,
+            n_week: 0,
+            add: 'hogehoge',
+          },
+        ]
+      }));
+    });
+
+    test('定休日の境界値', async () => {
+      const db = createAuthApp({uid: ownerUser.id});
+      const orgDocumentRef = orgsRef(db).doc(collectOrganization.id);
+      await orgDocumentRef.set(collectOrganization);
+
+      await firebase.assertFails(orgDocumentRef.update({
+        ...collectOrganization,
+        default_holidays: [
+          {
+            day_of_week: -1,
+            n_week: 0,
+          },
+        ]
+      }));
+      await firebase.assertFails(orgDocumentRef.update({
+        ...collectOrganization,
+        default_holidays: [
+          {
+            day_of_week: 7,
+            n_week: 0,
+          },
+        ]
+      }));
+      await firebase.assertFails(orgDocumentRef.update({
+        ...collectOrganization,
+        default_holidays: [
+          {
+            day_of_week: 1,
+            n_week: -1,
+          },
+        ]
+      }));
+      await firebase.assertFails(orgDocumentRef.update({
+        ...collectOrganization,
+        default_holidays: [
+          {
+            day_of_week: 1,
+            n_week: 5,
+          },
+        ]
+      }));
+    });
+  });
+});

--- a/firebase/tests/user.test.ts
+++ b/firebase/tests/user.test.ts
@@ -1,48 +1,16 @@
 import * as firebase from '@firebase/testing';
-import * as fs from 'fs';
 
-const PROJECT_ID = 'shiftend-47fca';
-const RULES_PATH = 'firestore.rules';
+import {clearData, collectUser, createAdminApp, createAuthApp, deleteApp, loadRules, usersRef} from './constant';
 
-// 認証付きのFreistore appを作成する
-const createAuthApp = (auth?: object): firebase.firestore.Firestore => {
-  return firebase.initializeTestApp({projectId: PROJECT_ID, auth: auth})
-      .firestore();
-};
-
-// 管理者権限で操作できるFreistore appを作成する
-const createAdminApp = (): firebase.firestore.Firestore => {
-  return firebase.initializeAdminApp({projectId: PROJECT_ID}).firestore();
-};
-
-// user情報への参照を作る
-const usersRef = (db: firebase.firestore.Firestore) => db.collection('users');
-
-describe('Firestoreセキュリティルール', () => {
+describe('Userモデルについてのセキュリティルール', () => {
   // ルールファイルの読み込み
-  beforeAll(async () => {
-    await firebase.loadFirestoreRules(
-        {projectId: PROJECT_ID, rules: fs.readFileSync(RULES_PATH, 'utf8')});
-  });
+  beforeAll(async () => {await loadRules()});
 
   // Firestoreデータのクリーンアップ
-  afterEach(async () => {
-    await firebase.clearFirestoreData({projectId: PROJECT_ID});
-  });
+  afterEach(async () => {await clearData()});
 
   // Firestoreアプリの削除
-  afterAll(async () => {
-    await Promise.all(firebase.apps().map(app => app.delete()));
-  });
-
-  const collectUser = {
-    id: 'test',
-    email: 'test@example.com',
-    icon_url: 'https://example.com/example.png',
-    name: 'テスト太郎',
-    role: 'アルバイト',
-    level: '100'
-  };
+  afterAll(async () => {await deleteApp()});
 
   describe('ユーザ認証情報の検証', () => {
     test(


### PR DESCRIPTION
## 対応するissue
- close #52 
- 
## 概要
組織の作成などの権限の検証，スキーマの検証用のテスト・セキュリティルールを作成

## 変更点・追加点
- テストの一般化できる場所を切り出しリファクタ
- 以下のテストを追加
  - 認証ユーザは，組織を作成可
  - 非認証ユーザは，組織作成不可
  - オーナーは，組織を閲覧，編集削除可能
  - メンバーである組織を閲覧可能
  - オーナーでないメンバーは，組織の編集削除不可
  - メンバー外は，閲覧，編集削除不可
  - 正しくないスキーマは作成できない，更新できない．
  - 定休日の境界値の検証

## 使い方/バグ再現手順
- docker-compose up -d
- npm test

## スクリーンショット等
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## コードレビューチェックリスト
- [ ] 仕様と実装はあっている
- [ ] 無意味なロジックがない
- [ ] DRYを守っている
- [ ] テストが適切に書かれている
- [ ] メソッド名、変数名などが適切
- [ ] コーディングルールを守れている
- [ ] メソッドからは予想できない副作用が含まれていない

チェックした人：
## その他特記事項
