### PR TITLE
userIdで参照していた部分をUserで直接見れるように変更

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+generate:
+	flutter pub pub run build_runner build --delete-conflicting-outputs

--- a/lib/debug_views/globals.dart
+++ b/lib/debug_views/globals.dart
@@ -12,6 +12,6 @@ final FirebaseAuth auth = FirebaseAuth.instance;
 final UserRepository userRepo =
     UserRepository(auth: auth, firestore: Firestore.instance);
 final OrganizationRepository orgRepo =
-    OrganizationRepository(firestore: Firestore.instance);
+    OrganizationRepository(firestore: Firestore.instance, userRepo: userRepo);
 final ShiftRepository shiftRepo =
     ShiftRepository(firestore: Firestore.instance);

--- a/lib/debug_views/globals.dart
+++ b/lib/debug_views/globals.dart
@@ -14,4 +14,4 @@ final UserRepository userRepo =
 final OrganizationRepository orgRepo =
     OrganizationRepository(firestore: Firestore.instance, userRepo: userRepo);
 final ShiftRepository shiftRepo =
-    ShiftRepository(firestore: Firestore.instance);
+    ShiftRepository(firestore: Firestore.instance, userRepo: userRepo);

--- a/lib/debug_views/organization_dialog.dart
+++ b/lib/debug_views/organization_dialog.dart
@@ -170,8 +170,8 @@ class OrganizationDialog {
     try {
       org = Organization(
         id: id,
-        ownerIds: <String>[user.id],
-        memberIds: <String>[user.id],
+        owners: <User>[user],
+        members: <User>[user],
         defaultHolidays: <Holiday>[
           const Holiday(dayOfWeek: 0, nWeek: 0),
           const Holiday(dayOfWeek: 1, nWeek: 1),

--- a/lib/debug_views/shift_dialog.dart
+++ b/lib/debug_views/shift_dialog.dart
@@ -8,6 +8,7 @@ class ShiftDialog {
   static void showShiftCreateDialog(BuildContext context) {
     final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
     String orgId;
+    String userId;
     Shift shift = const Shift();
     showDialog<dynamic>(
       context: context,
@@ -38,7 +39,8 @@ class ShiftDialog {
                   labelText: 'User id',
                 ),
                 onSaved: (String value) {
-                  shift = shift.copyWith(userId: value);
+                  userId = value;
+                  print(userId);
                 },
                 validator: (value) {
                   if (value.isEmpty) {
@@ -91,10 +93,14 @@ class ShiftDialog {
           ),
           FlatButton(
             child: const Text('作成'),
-            onPressed: () {
+            onPressed: () async {
               if (_formKey.currentState.validate()) {
                 _formKey.currentState.save();
-                shiftRepo.create(orgId, shift);
+                print(userId);
+                final user = await userRepo.getUser(userId);
+                shift = shift.copyWith(user: user);
+                print(shift);
+                await shiftRepo.create(orgId, shift);
                 Navigator.pop(context);
               }
             },
@@ -136,8 +142,8 @@ class ShiftDialog {
                   icon: Icon(Icons.mail),
                   labelText: 'User id',
                 ),
-                onSaved: (String value) {
-                  shift = shift.copyWith(userId: value);
+                onSaved: (String value) async {
+                  shift = shift.copyWith(user: await userRepo.getUser(value));
                 },
                 validator: (value) {
                   if (value.isEmpty) {

--- a/lib/debug_views/shift_dialog.dart
+++ b/lib/debug_views/shift_dialog.dart
@@ -97,7 +97,7 @@ class ShiftDialog {
               if (_formKey.currentState.validate()) {
                 _formKey.currentState.save();
                 print(userId);
-                final user = await userRepo.getUser(userId);
+                final User user = await userRepo.getUser(userId);
                 shift = shift.copyWith(user: user);
                 print(shift);
                 await shiftRepo.create(orgId, shift);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ import 'package:shiftend/pages/login/login_state.dart';
 import 'package:shiftend/pages/login/login_state_controller.dart';
 import 'package:shiftend/pages/setting/setting_page.dart';
 import 'package:shiftend/repositories/mocks/shift_repository_mock.dart';
+import 'package:shiftend/repositories/mocks/user_repository_mock.dart';
 import 'package:shiftend/repositories/shift_repository.dart';
 import 'package:shiftend/repositories/user_repository.dart';
 
@@ -27,10 +28,13 @@ class MyApp extends StatelessWidget {
     return MultiProvider(
       providers: [
         Provider<ShiftRepository>.value(
-          value: ShiftRepository(firestore: Firestore.instance),
+          value: ShiftRepository(
+              firestore: Firestore.instance,
+              userRepo: UserRepository(
+                  firestore: Firestore.instance, auth: FirebaseAuth.instance)),
         ),
         Provider<ShiftRepositoryMock>.value(
-          value: ShiftRepositoryMock(),
+          value: ShiftRepositoryMock(userRepo: UserRepositoryMock()),
         ),
         Provider<UserRepository>.value(
           value: UserRepository(

--- a/lib/models/organization/organization.dart
+++ b/lib/models/organization/organization.dart
@@ -12,8 +12,8 @@ part 'organization.g.dart';
 abstract class Organization with _$Organization {
   const factory Organization({
     String id,
-    @JsonKey(name: 'owner_ids') List<String> ownerIds,
-    @JsonKey(name: 'member_ids') List<String> memberIds,
+    @UserConverter() @JsonKey(name: 'owners') List<User> owners,
+    @UserConverter() @JsonKey(name: 'members') List<User> members,
     @JsonKey(name: 'default_holidays')
     @HolidayConverter()
         List<Holiday> defaultHolidays,

--- a/lib/models/organization/organization.freezed.dart
+++ b/lib/models/organization/organization.freezed.dart
@@ -17,17 +17,19 @@ class _$OrganizationTearOff {
 
   _Organization call(
       {String id,
-      @JsonKey(name: 'owner_ids')
-          List<String> ownerIds,
-      @JsonKey(name: 'member_ids')
-          List<String> memberIds,
+      @UserConverter()
+      @JsonKey(name: 'owners')
+          List<User> owners,
+      @UserConverter()
+      @JsonKey(name: 'members')
+          List<User> members,
       @JsonKey(name: 'default_holidays')
       @HolidayConverter()
           List<Holiday> defaultHolidays}) {
     return _Organization(
       id: id,
-      ownerIds: ownerIds,
-      memberIds: memberIds,
+      owners: owners,
+      members: members,
       defaultHolidays: defaultHolidays,
     );
   }
@@ -38,10 +40,12 @@ const $Organization = _$OrganizationTearOff();
 
 mixin _$Organization {
   String get id;
-  @JsonKey(name: 'owner_ids')
-  List<String> get ownerIds;
-  @JsonKey(name: 'member_ids')
-  List<String> get memberIds;
+  @UserConverter()
+  @JsonKey(name: 'owners')
+  List<User> get owners;
+  @UserConverter()
+  @JsonKey(name: 'members')
+  List<User> get members;
   @JsonKey(name: 'default_holidays')
   @HolidayConverter()
   List<Holiday> get defaultHolidays;
@@ -56,10 +60,12 @@ abstract class $OrganizationCopyWith<$Res> {
       _$OrganizationCopyWithImpl<$Res>;
   $Res call(
       {String id,
-      @JsonKey(name: 'owner_ids')
-          List<String> ownerIds,
-      @JsonKey(name: 'member_ids')
-          List<String> memberIds,
+      @UserConverter()
+      @JsonKey(name: 'owners')
+          List<User> owners,
+      @UserConverter()
+      @JsonKey(name: 'members')
+          List<User> members,
       @JsonKey(name: 'default_holidays')
       @HolidayConverter()
           List<Holiday> defaultHolidays});
@@ -75,16 +81,14 @@ class _$OrganizationCopyWithImpl<$Res> implements $OrganizationCopyWith<$Res> {
   @override
   $Res call({
     Object id = freezed,
-    Object ownerIds = freezed,
-    Object memberIds = freezed,
+    Object owners = freezed,
+    Object members = freezed,
     Object defaultHolidays = freezed,
   }) {
     return _then(_value.copyWith(
       id: id == freezed ? _value.id : id as String,
-      ownerIds:
-          ownerIds == freezed ? _value.ownerIds : ownerIds as List<String>,
-      memberIds:
-          memberIds == freezed ? _value.memberIds : memberIds as List<String>,
+      owners: owners == freezed ? _value.owners : owners as List<User>,
+      members: members == freezed ? _value.members : members as List<User>,
       defaultHolidays: defaultHolidays == freezed
           ? _value.defaultHolidays
           : defaultHolidays as List<Holiday>,
@@ -100,10 +104,12 @@ abstract class _$OrganizationCopyWith<$Res>
   @override
   $Res call(
       {String id,
-      @JsonKey(name: 'owner_ids')
-          List<String> ownerIds,
-      @JsonKey(name: 'member_ids')
-          List<String> memberIds,
+      @UserConverter()
+      @JsonKey(name: 'owners')
+          List<User> owners,
+      @UserConverter()
+      @JsonKey(name: 'members')
+          List<User> members,
       @JsonKey(name: 'default_holidays')
       @HolidayConverter()
           List<Holiday> defaultHolidays});
@@ -121,16 +127,14 @@ class __$OrganizationCopyWithImpl<$Res> extends _$OrganizationCopyWithImpl<$Res>
   @override
   $Res call({
     Object id = freezed,
-    Object ownerIds = freezed,
-    Object memberIds = freezed,
+    Object owners = freezed,
+    Object members = freezed,
     Object defaultHolidays = freezed,
   }) {
     return _then(_Organization(
       id: id == freezed ? _value.id : id as String,
-      ownerIds:
-          ownerIds == freezed ? _value.ownerIds : ownerIds as List<String>,
-      memberIds:
-          memberIds == freezed ? _value.memberIds : memberIds as List<String>,
+      owners: owners == freezed ? _value.owners : owners as List<User>,
+      members: members == freezed ? _value.members : members as List<User>,
       defaultHolidays: defaultHolidays == freezed
           ? _value.defaultHolidays
           : defaultHolidays as List<Holiday>,
@@ -142,10 +146,12 @@ class __$OrganizationCopyWithImpl<$Res> extends _$OrganizationCopyWithImpl<$Res>
 class _$_Organization with DiagnosticableTreeMixin implements _Organization {
   const _$_Organization(
       {this.id,
-      @JsonKey(name: 'owner_ids')
-          this.ownerIds,
-      @JsonKey(name: 'member_ids')
-          this.memberIds,
+      @UserConverter()
+      @JsonKey(name: 'owners')
+          this.owners,
+      @UserConverter()
+      @JsonKey(name: 'members')
+          this.members,
       @JsonKey(name: 'default_holidays')
       @HolidayConverter()
           this.defaultHolidays});
@@ -156,11 +162,13 @@ class _$_Organization with DiagnosticableTreeMixin implements _Organization {
   @override
   final String id;
   @override
-  @JsonKey(name: 'owner_ids')
-  final List<String> ownerIds;
+  @UserConverter()
+  @JsonKey(name: 'owners')
+  final List<User> owners;
   @override
-  @JsonKey(name: 'member_ids')
-  final List<String> memberIds;
+  @UserConverter()
+  @JsonKey(name: 'members')
+  final List<User> members;
   @override
   @JsonKey(name: 'default_holidays')
   @HolidayConverter()
@@ -168,7 +176,7 @@ class _$_Organization with DiagnosticableTreeMixin implements _Organization {
 
   @override
   String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
-    return 'Organization(id: $id, ownerIds: $ownerIds, memberIds: $memberIds, defaultHolidays: $defaultHolidays)';
+    return 'Organization(id: $id, owners: $owners, members: $members, defaultHolidays: $defaultHolidays)';
   }
 
   @override
@@ -177,8 +185,8 @@ class _$_Organization with DiagnosticableTreeMixin implements _Organization {
     properties
       ..add(DiagnosticsProperty('type', 'Organization'))
       ..add(DiagnosticsProperty('id', id))
-      ..add(DiagnosticsProperty('ownerIds', ownerIds))
-      ..add(DiagnosticsProperty('memberIds', memberIds))
+      ..add(DiagnosticsProperty('owners', owners))
+      ..add(DiagnosticsProperty('members', members))
       ..add(DiagnosticsProperty('defaultHolidays', defaultHolidays));
   }
 
@@ -188,12 +196,11 @@ class _$_Organization with DiagnosticableTreeMixin implements _Organization {
         (other is _Organization &&
             (identical(other.id, id) ||
                 const DeepCollectionEquality().equals(other.id, id)) &&
-            (identical(other.ownerIds, ownerIds) ||
+            (identical(other.owners, owners) ||
+                const DeepCollectionEquality().equals(other.owners, owners)) &&
+            (identical(other.members, members) ||
                 const DeepCollectionEquality()
-                    .equals(other.ownerIds, ownerIds)) &&
-            (identical(other.memberIds, memberIds) ||
-                const DeepCollectionEquality()
-                    .equals(other.memberIds, memberIds)) &&
+                    .equals(other.members, members)) &&
             (identical(other.defaultHolidays, defaultHolidays) ||
                 const DeepCollectionEquality()
                     .equals(other.defaultHolidays, defaultHolidays)));
@@ -203,8 +210,8 @@ class _$_Organization with DiagnosticableTreeMixin implements _Organization {
   int get hashCode =>
       runtimeType.hashCode ^
       const DeepCollectionEquality().hash(id) ^
-      const DeepCollectionEquality().hash(ownerIds) ^
-      const DeepCollectionEquality().hash(memberIds) ^
+      const DeepCollectionEquality().hash(owners) ^
+      const DeepCollectionEquality().hash(members) ^
       const DeepCollectionEquality().hash(defaultHolidays);
 
   @override
@@ -220,10 +227,12 @@ class _$_Organization with DiagnosticableTreeMixin implements _Organization {
 abstract class _Organization implements Organization {
   const factory _Organization(
       {String id,
-      @JsonKey(name: 'owner_ids')
-          List<String> ownerIds,
-      @JsonKey(name: 'member_ids')
-          List<String> memberIds,
+      @UserConverter()
+      @JsonKey(name: 'owners')
+          List<User> owners,
+      @UserConverter()
+      @JsonKey(name: 'members')
+          List<User> members,
       @JsonKey(name: 'default_holidays')
       @HolidayConverter()
           List<Holiday> defaultHolidays}) = _$_Organization;
@@ -234,11 +243,13 @@ abstract class _Organization implements Organization {
   @override
   String get id;
   @override
-  @JsonKey(name: 'owner_ids')
-  List<String> get ownerIds;
+  @UserConverter()
+  @JsonKey(name: 'owners')
+  List<User> get owners;
   @override
-  @JsonKey(name: 'member_ids')
-  List<String> get memberIds;
+  @UserConverter()
+  @JsonKey(name: 'members')
+  List<User> get members;
   @override
   @JsonKey(name: 'default_holidays')
   @HolidayConverter()

--- a/lib/models/organization/organization.g.dart
+++ b/lib/models/organization/organization.g.dart
@@ -9,8 +9,12 @@ part of 'organization.dart';
 _$_Organization _$_$_OrganizationFromJson(Map<String, dynamic> json) {
   return _$_Organization(
     id: json['id'] as String,
-    ownerIds: (json['owner_ids'] as List)?.map((e) => e as String)?.toList(),
-    memberIds: (json['member_ids'] as List)?.map((e) => e as String)?.toList(),
+    owners: (json['owners'] as List)
+        ?.map((e) => const UserConverter().fromJson(e as Map<String, dynamic>))
+        ?.toList(),
+    members: (json['members'] as List)
+        ?.map((e) => const UserConverter().fromJson(e as Map<String, dynamic>))
+        ?.toList(),
     defaultHolidays: (json['default_holidays'] as List)
         ?.map(
             (e) => const HolidayConverter().fromJson(e as Map<String, dynamic>))
@@ -21,8 +25,8 @@ _$_Organization _$_$_OrganizationFromJson(Map<String, dynamic> json) {
 Map<String, dynamic> _$_$_OrganizationToJson(_$_Organization instance) =>
     <String, dynamic>{
       'id': instance.id,
-      'owner_ids': instance.ownerIds,
-      'member_ids': instance.memberIds,
+      'owners': instance.owners?.map(const UserConverter().toJson)?.toList(),
+      'members': instance.members?.map(const UserConverter().toJson)?.toList(),
       'default_holidays': instance.defaultHolidays
           ?.map(const HolidayConverter().toJson)
           ?.toList(),

--- a/lib/models/shift/shift.dart
+++ b/lib/models/shift/shift.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/foundation.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:shiftend/models/converter/converter.dart';
+import 'package:shiftend/models/models.dart';
 part 'shift.freezed.dart';
 part 'shift.g.dart';
 
 @freezed
 abstract class Shift with _$Shift {
   const factory Shift({
-    @JsonKey(name: 'user_id') String userId,
+    @UserConverter() @JsonKey(name: 'user') User user,
     DateTime start,
     DateTime end,
   }) = _Shift;

--- a/lib/models/shift/shift.freezed.dart
+++ b/lib/models/shift/shift.freezed.dart
@@ -16,9 +16,11 @@ class _$ShiftTearOff {
   const _$ShiftTearOff();
 
   _Shift call(
-      {@JsonKey(name: 'user_id') String userId, DateTime start, DateTime end}) {
+      {@UserConverter() @JsonKey(name: 'user') User user,
+      DateTime start,
+      DateTime end}) {
     return _Shift(
-      userId: userId,
+      user: user,
       start: start,
       end: end,
     );
@@ -29,8 +31,9 @@ class _$ShiftTearOff {
 const $Shift = _$ShiftTearOff();
 
 mixin _$Shift {
-  @JsonKey(name: 'user_id')
-  String get userId;
+  @UserConverter()
+  @JsonKey(name: 'user')
+  User get user;
   DateTime get start;
   DateTime get end;
 
@@ -42,7 +45,9 @@ abstract class $ShiftCopyWith<$Res> {
   factory $ShiftCopyWith(Shift value, $Res Function(Shift) then) =
       _$ShiftCopyWithImpl<$Res>;
   $Res call(
-      {@JsonKey(name: 'user_id') String userId, DateTime start, DateTime end});
+      {@UserConverter() @JsonKey(name: 'user') User user,
+      DateTime start,
+      DateTime end});
 }
 
 class _$ShiftCopyWithImpl<$Res> implements $ShiftCopyWith<$Res> {
@@ -54,12 +59,12 @@ class _$ShiftCopyWithImpl<$Res> implements $ShiftCopyWith<$Res> {
 
   @override
   $Res call({
-    Object userId = freezed,
+    Object user = freezed,
     Object start = freezed,
     Object end = freezed,
   }) {
     return _then(_value.copyWith(
-      userId: userId == freezed ? _value.userId : userId as String,
+      user: user == freezed ? _value.user : user as User,
       start: start == freezed ? _value.start : start as DateTime,
       end: end == freezed ? _value.end : end as DateTime,
     ));
@@ -71,7 +76,9 @@ abstract class _$ShiftCopyWith<$Res> implements $ShiftCopyWith<$Res> {
       __$ShiftCopyWithImpl<$Res>;
   @override
   $Res call(
-      {@JsonKey(name: 'user_id') String userId, DateTime start, DateTime end});
+      {@UserConverter() @JsonKey(name: 'user') User user,
+      DateTime start,
+      DateTime end});
 }
 
 class __$ShiftCopyWithImpl<$Res> extends _$ShiftCopyWithImpl<$Res>
@@ -84,12 +91,12 @@ class __$ShiftCopyWithImpl<$Res> extends _$ShiftCopyWithImpl<$Res>
 
   @override
   $Res call({
-    Object userId = freezed,
+    Object user = freezed,
     Object start = freezed,
     Object end = freezed,
   }) {
     return _then(_Shift(
-      userId: userId == freezed ? _value.userId : userId as String,
+      user: user == freezed ? _value.user : user as User,
       start: start == freezed ? _value.start : start as DateTime,
       end: end == freezed ? _value.end : end as DateTime,
     ));
@@ -98,14 +105,18 @@ class __$ShiftCopyWithImpl<$Res> extends _$ShiftCopyWithImpl<$Res>
 
 @JsonSerializable()
 class _$_Shift with DiagnosticableTreeMixin implements _Shift {
-  const _$_Shift({@JsonKey(name: 'user_id') this.userId, this.start, this.end});
+  const _$_Shift(
+      {@UserConverter() @JsonKey(name: 'user') this.user,
+      this.start,
+      this.end});
 
   factory _$_Shift.fromJson(Map<String, dynamic> json) =>
       _$_$_ShiftFromJson(json);
 
   @override
-  @JsonKey(name: 'user_id')
-  final String userId;
+  @UserConverter()
+  @JsonKey(name: 'user')
+  final User user;
   @override
   final DateTime start;
   @override
@@ -113,7 +124,7 @@ class _$_Shift with DiagnosticableTreeMixin implements _Shift {
 
   @override
   String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
-    return 'Shift(userId: $userId, start: $start, end: $end)';
+    return 'Shift(user: $user, start: $start, end: $end)';
   }
 
   @override
@@ -121,7 +132,7 @@ class _$_Shift with DiagnosticableTreeMixin implements _Shift {
     super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('type', 'Shift'))
-      ..add(DiagnosticsProperty('userId', userId))
+      ..add(DiagnosticsProperty('user', user))
       ..add(DiagnosticsProperty('start', start))
       ..add(DiagnosticsProperty('end', end));
   }
@@ -130,8 +141,8 @@ class _$_Shift with DiagnosticableTreeMixin implements _Shift {
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other is _Shift &&
-            (identical(other.userId, userId) ||
-                const DeepCollectionEquality().equals(other.userId, userId)) &&
+            (identical(other.user, user) ||
+                const DeepCollectionEquality().equals(other.user, user)) &&
             (identical(other.start, start) ||
                 const DeepCollectionEquality().equals(other.start, start)) &&
             (identical(other.end, end) ||
@@ -141,7 +152,7 @@ class _$_Shift with DiagnosticableTreeMixin implements _Shift {
   @override
   int get hashCode =>
       runtimeType.hashCode ^
-      const DeepCollectionEquality().hash(userId) ^
+      const DeepCollectionEquality().hash(user) ^
       const DeepCollectionEquality().hash(start) ^
       const DeepCollectionEquality().hash(end);
 
@@ -157,15 +168,16 @@ class _$_Shift with DiagnosticableTreeMixin implements _Shift {
 
 abstract class _Shift implements Shift {
   const factory _Shift(
-      {@JsonKey(name: 'user_id') String userId,
+      {@UserConverter() @JsonKey(name: 'user') User user,
       DateTime start,
       DateTime end}) = _$_Shift;
 
   factory _Shift.fromJson(Map<String, dynamic> json) = _$_Shift.fromJson;
 
   @override
-  @JsonKey(name: 'user_id')
-  String get userId;
+  @UserConverter()
+  @JsonKey(name: 'user')
+  User get user;
   @override
   DateTime get start;
   @override

--- a/lib/models/shift/shift.g.dart
+++ b/lib/models/shift/shift.g.dart
@@ -8,7 +8,7 @@ part of 'shift.dart';
 
 _$_Shift _$_$_ShiftFromJson(Map<String, dynamic> json) {
   return _$_Shift(
-    userId: json['user_id'] as String,
+    user: json['user'],
     start:
         json['start'] == null ? null : DateTime.parse(json['start'] as String),
     end: json['end'] == null ? null : DateTime.parse(json['end'] as String),
@@ -16,7 +16,7 @@ _$_Shift _$_$_ShiftFromJson(Map<String, dynamic> json) {
 }
 
 Map<String, dynamic> _$_$_ShiftToJson(_$_Shift instance) => <String, dynamic>{
-      'user_id': instance.userId,
+      'user': instance.user,
       'start': instance.start?.toIso8601String(),
       'end': instance.end?.toIso8601String(),
     };

--- a/lib/pages/calendar/calendar_state_controller.dart
+++ b/lib/pages/calendar/calendar_state_controller.dart
@@ -27,7 +27,7 @@ class CalendarStateController extends StateNotifier<CalendarState>
   Future<void> fetchShiftsInitial(DateTime date) async {
     state = state.copyWith(notifierState: NotifierState.loading);
 
-    final shifts = await shiftRepository.getShifts('batchOrg1', date);
+    final shifts = await shiftRepository.getShifts('refOrg', date);
     final formattedNow = _dateFormatter.format(state.selectedDate);
     state = state.copyWith(shifts: shifts, notifierState: NotifierState.loaded);
     state = state.copyWith(selectedShifts: shifts[formattedNow]);

--- a/lib/pages/calendar/calendar_state_controller.dart
+++ b/lib/pages/calendar/calendar_state_controller.dart
@@ -36,7 +36,7 @@ class CalendarStateController extends StateNotifier<CalendarState>
   // カレンダーで月を変えるごとに月ごとのデータを取得する
   Future<void> fetchShiftsOfMonth(DateTime date) async {
     // TODO: getShiftsのorgIdは今後動的に変えられるようにする．今は固定
-    final shifts = await shiftRepository.getShifts('batchOrg1', date);
+    final shifts = await shiftRepository.getShifts('refOrg', date);
     state = state.copyWith(shifts: shifts);
     print(shifts);
   }

--- a/lib/repositories/interfaces/user_repository_interface.dart
+++ b/lib/repositories/interfaces/user_repository_interface.dart
@@ -10,10 +10,7 @@ abstract class UserRepositoryInterface {
   Future<User> getCurrentUser();
   Future<User> getUser(String userId);
   Future<List<User>> getUsers();
-<<<<<<< HEAD
   Future<bool> isLogin();
-=======
   Future<DocumentReference> getUserRef(String userId);
   Future<User> fromUserRef(DocumentReference userRef);
->>>>>>> ca0ec6b... feat: organizationのUserを参照型に変更
 }

--- a/lib/repositories/interfaces/user_repository_interface.dart
+++ b/lib/repositories/interfaces/user_repository_interface.dart
@@ -1,3 +1,4 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:shiftend/models/models.dart';
 
 abstract class UserRepositoryInterface {
@@ -8,5 +9,10 @@ abstract class UserRepositoryInterface {
   Future<void> update(User user);
   Future<User> getCurrentUser();
   Future<List<User>> getUsers();
+<<<<<<< HEAD
   Future<bool> isLogin();
+=======
+  Future<DocumentReference> getUserRef(String userId);
+  Future<User> fromUserRef(DocumentReference userRef);
+>>>>>>> ca0ec6b... feat: organizationのUserを参照型に変更
 }

--- a/lib/repositories/interfaces/user_repository_interface.dart
+++ b/lib/repositories/interfaces/user_repository_interface.dart
@@ -8,6 +8,7 @@ abstract class UserRepositoryInterface {
   Future<void> create(User user);
   Future<void> update(User user);
   Future<User> getCurrentUser();
+  Future<User> getUser(String userId);
   Future<List<User>> getUsers();
 <<<<<<< HEAD
   Future<bool> isLogin();

--- a/lib/repositories/mocks/organization_repository_mock.dart
+++ b/lib/repositories/mocks/organization_repository_mock.dart
@@ -1,4 +1,5 @@
 import 'package:shiftend/models/holiday/holiday.dart';
+import 'package:shiftend/models/models.dart';
 import 'package:shiftend/models/organization/organization.dart';
 import 'package:shiftend/repositories/interfaces/organization_repository_interface.dart';
 import 'package:shiftend/repositories/mocks/user_repository_mock.dart';
@@ -9,8 +10,8 @@ class OrganizationRepositoryMock extends OrganizationRepositoryInterface {
     orgs.add(
       Organization(
         id: 'test_id',
-        ownerIds: <String>[_userRepo.currentUser.id],
-        memberIds: <String>[_userRepo.currentUser.id],
+        owners: <User>[_userRepo.currentUser],
+        members: <User>[_userRepo.currentUser],
         defaultHolidays: <Holiday>[
           const Holiday(dayOfWeek: 0, nWeek: 0),
           const Holiday(dayOfWeek: 1, nWeek: 1),
@@ -42,9 +43,11 @@ class OrganizationRepositoryMock extends OrganizationRepositoryInterface {
   Future<List<Organization>> getOrganizations(String ownerId) async {
     List<Organization> ownedOrgs;
     for (final org in orgs) {
-      if (org.ownerIds.contains(ownerId)) {
-        ownedOrgs.add(org);
+      final ownerIndex = org.owners.indexWhere((user) => user.id == ownerId);
+      if (ownerIndex == -1) {
+        continue;
       }
+      ownedOrgs.add(org);
     }
     return ownedOrgs;
   }

--- a/lib/repositories/mocks/organization_repository_mock.dart
+++ b/lib/repositories/mocks/organization_repository_mock.dart
@@ -43,7 +43,8 @@ class OrganizationRepositoryMock extends OrganizationRepositoryInterface {
   Future<List<Organization>> getOrganizations(String ownerId) async {
     List<Organization> ownedOrgs;
     for (final org in orgs) {
-      final ownerIndex = org.owners.indexWhere((user) => user.id == ownerId);
+      final int ownerIndex =
+          org.owners.indexWhere((user) => user.id == ownerId);
       if (ownerIndex == -1) {
         continue;
       }

--- a/lib/repositories/mocks/shift_repository_mock.dart
+++ b/lib/repositories/mocks/shift_repository_mock.dart
@@ -1,58 +1,65 @@
+import 'package:flutter/material.dart';
 import 'package:shiftend/models/shift/shift.dart';
 import 'package:shiftend/repositories/interfaces/shift_repository_interface.dart';
 
+import 'user_repository_mock.dart';
+
 class ShiftRepositoryMock extends ShiftRepositoryInterface {
-  // shifts[orgId][2020年7月][1] = shift_list
-  Map<String, Map<DateTime, Map<DateTime, List<Shift>>>> shifts = {
-    'ten': {
-      DateTime(2020, 7): {
-        DateTime(2020, 7, 3): <Shift>[
-          Shift(
-              userId: '0',
-              start: DateTime.parse('2020-07-03 17:00'),
-              end: DateTime.parse('2020-07-03 22:30')),
-          Shift(
-              userId: '1',
-              start: DateTime.parse('2020-07-03 17:00'),
-              end: DateTime.parse('2020-07-04 02:00')),
-        ],
-        DateTime(2020, 7, 10): <Shift>[
-          Shift(
-              userId: '0',
-              start: DateTime.parse('2020-07-10 17:00'),
-              end: DateTime.parse('2020-07-10 22:30')),
-          Shift(
-              userId: '1',
-              start: DateTime.parse('2020-07-10 17:00'),
-              end: DateTime.parse('2020-07-11 02:00')),
-        ],
-        DateTime(2020, 7, 20): <Shift>[
-          Shift(
-              userId: '0',
-              start: DateTime.parse('2020-07-20 17:00'),
-              end: DateTime.parse('2020-07-20 22:30')),
-          Shift(
-              userId: '1',
-              start: DateTime.parse('2020-07-20 17:00'),
-              end: DateTime.parse('2020-07-21 02:00')),
-          Shift(
-              userId: '2',
-              start: DateTime.parse('2020-07-20 18:00'),
-              end: DateTime.parse('2020-07-21 00:00')),
-        ],
-        DateTime(2020, 7, 22): <Shift>[
-          Shift(
-              userId: '0',
-              start: DateTime.parse('2020-07-22 17:00'),
-              end: DateTime.parse('2020-07-22 22:30')),
-          Shift(
-              userId: '1',
-              start: DateTime.parse('2020-07-22 17:00'),
-              end: DateTime.parse('2020-07-23 02:00')),
-        ],
+  ShiftRepositoryMock({@required this.userRepo}) : assert(userRepo != null) {
+    shifts = {
+      'ten': {
+        DateTime(2020, 7): {
+          DateTime(2020, 7, 3): <Shift>[
+            Shift(
+                user: userRepo.users.singleWhere((user) => user.id == '0'),
+                start: DateTime.parse('2020-07-03 17:00'),
+                end: DateTime.parse('2020-07-03 22:30')),
+            Shift(
+                user: userRepo.users.singleWhere((user) => user.id == '1'),
+                start: DateTime.parse('2020-07-03 17:00'),
+                end: DateTime.parse('2020-07-04 02:00')),
+          ],
+          DateTime(2020, 7, 10): <Shift>[
+            Shift(
+                user: userRepo.users.singleWhere((user) => user.id == '0'),
+                start: DateTime.parse('2020-07-10 17:00'),
+                end: DateTime.parse('2020-07-10 22:30')),
+            Shift(
+                user: userRepo.users.singleWhere((user) => user.id == '1'),
+                start: DateTime.parse('2020-07-10 17:00'),
+                end: DateTime.parse('2020-07-11 02:00')),
+          ],
+          DateTime(2020, 7, 20): <Shift>[
+            Shift(
+                user: userRepo.users.singleWhere((user) => user.id == '0'),
+                start: DateTime.parse('2020-07-20 17:00'),
+                end: DateTime.parse('2020-07-20 22:30')),
+            Shift(
+                user: userRepo.users.singleWhere((user) => user.id == '1'),
+                start: DateTime.parse('2020-07-20 17:00'),
+                end: DateTime.parse('2020-07-21 02:00')),
+            Shift(
+                user: userRepo.users.singleWhere((user) => user.id == '2'),
+                start: DateTime.parse('2020-07-20 18:00'),
+                end: DateTime.parse('2020-07-21 00:00')),
+          ],
+          DateTime(2020, 7, 22): <Shift>[
+            Shift(
+                user: userRepo.users.singleWhere((user) => user.id == '0'),
+                start: DateTime.parse('2020-07-22 17:00'),
+                end: DateTime.parse('2020-07-22 22:30')),
+            Shift(
+                user: userRepo.users.singleWhere((user) => user.id == '1'),
+                start: DateTime.parse('2020-07-22 17:00'),
+                end: DateTime.parse('2020-07-23 02:00')),
+          ],
+        }
       }
-    }
-  };
+    };
+  }
+  UserRepositoryMock userRepo;
+  // shifts[orgId][2020年7月][1] = shift_list
+  Map<String, Map<DateTime, Map<DateTime, List<Shift>>>> shifts;
   @override
   Future<void> create(String orgId, Shift shift) async {
     final year = shift.start.year;
@@ -62,7 +69,7 @@ class ShiftRepositoryMock extends ShiftRepositoryInterface {
     final shiftList = shifts[orgId][ym][day];
     bool isExist = false;
     shiftList.forEach((s) {
-      if (s.userId == shift.userId) {
+      if (s.user.id == shift.user.id) {
         isExist = true;
       }
     });
@@ -78,7 +85,7 @@ class ShiftRepositoryMock extends ShiftRepositoryInterface {
     final month = day.month;
     final d = day.day;
     final ym = DateTime(year, month);
-    shifts[orgId][ym][d].removeWhere((s) => s.userId == userId);
+    shifts[orgId][ym][d].removeWhere((s) => s.user.id == userId);
   }
 
   @override
@@ -90,7 +97,7 @@ class ShiftRepositoryMock extends ShiftRepositoryInterface {
 
   @override
   Future<void> update(String orgId, Shift shift) async {
-    await delete(orgId, shift.start, shift.userId);
+    await delete(orgId, shift.start, shift.user.id);
     await create(orgId, shift);
   }
 }

--- a/lib/repositories/mocks/user_repository_mock.dart
+++ b/lib/repositories/mocks/user_repository_mock.dart
@@ -1,7 +1,8 @@
 import 'dart:async';
 
-import 'package:shiftend/repositories/interfaces/user_repository_interface.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:shiftend/models/models.dart';
+import 'package:shiftend/repositories/interfaces/user_repository_interface.dart';
 
 class UserRepositoryMock extends UserRepositoryInterface {
   List<User> users = <User>[
@@ -79,12 +80,20 @@ class UserRepositoryMock extends UserRepositoryInterface {
   @override
   Future<void> signIn(String email, String password) {
     // TODO: implement signIn
+  }
+
+  Future<DocumentReference> getUserRef(String userId) {
+    // TODO: implement getUserRef
     throw UnimplementedError();
   }
 
   @override
   Future<void> signOut() {
     // TODO: implement signOut
+  }
+
+  Future<User> fromUserRef(DocumentReference userRef) {
+    // TODO: implement fromUserRef
     throw UnimplementedError();
   }
 }

--- a/lib/repositories/mocks/user_repository_mock.dart
+++ b/lib/repositories/mocks/user_repository_mock.dart
@@ -81,8 +81,10 @@ class UserRepositoryMock extends UserRepositoryInterface {
   @override
   Future<void> signIn(String email, String password) {
     // TODO: implement signIn
+    throw UnimplementedError();
   }
 
+  @override
   Future<DocumentReference> getUserRef(String userId) {
     // TODO: implement getUserRef
     throw UnimplementedError();
@@ -91,8 +93,10 @@ class UserRepositoryMock extends UserRepositoryInterface {
   @override
   Future<void> signOut() {
     // TODO: implement signOut
+    throw UnimplementedError();
   }
 
+  @override
   Future<User> fromUserRef(DocumentReference userRef) {
     // TODO: implement fromUserRef
     throw UnimplementedError();

--- a/lib/repositories/mocks/user_repository_mock.dart
+++ b/lib/repositories/mocks/user_repository_mock.dart
@@ -5,7 +5,7 @@ import 'package:shiftend/models/models.dart';
 import 'package:shiftend/repositories/interfaces/user_repository_interface.dart';
 
 class UserRepositoryMock extends UserRepositoryInterface {
-  List<User> users = <User>[
+  final List<User> _users = <User>[
     const User(
         id: '0',
         email: 'test@example.com',
@@ -31,6 +31,7 @@ class UserRepositoryMock extends UserRepositoryInterface {
         role: 'バイトリーダ',
         level: '50'),
   ];
+  List<User> get users => _users;
   User currentUser = const User(
       id: 'test_user',
       email: 'test@example.com',
@@ -95,5 +96,10 @@ class UserRepositoryMock extends UserRepositoryInterface {
   Future<User> fromUserRef(DocumentReference userRef) {
     // TODO: implement fromUserRef
     throw UnimplementedError();
+  }
+
+  @override
+  Future<User> getUser(String userId) async {
+    return users.singleWhere((user) => user.id == userId);
   }
 }

--- a/lib/repositories/organization_repository.dart
+++ b/lib/repositories/organization_repository.dart
@@ -26,7 +26,7 @@ class OrganizationRepository extends OrganizationRepositoryInterface {
 
   @override
   Future<Organization> getOrganization(String id) async {
-    final json =
+    final Map<String, dynamic> json =
         (await firestore.collection(collectionName).document(id).get()).data;
 
     return _fromJson(json);
@@ -52,8 +52,8 @@ class OrganizationRepository extends OrganizationRepositoryInterface {
   }
 
   Future<List<DocumentReference>> _getUsersRef(List<User> users) async {
-    final usersRef = <DocumentReference>[];
-    for (final user in users) {
+    final List<DocumentReference> usersRef = <DocumentReference>[];
+    for (final User user in users) {
       usersRef.add(await userRepo.getUserRef(user.id));
     }
     return usersRef;
@@ -63,7 +63,7 @@ class OrganizationRepository extends OrganizationRepositoryInterface {
     final Map<String, dynamic> result = <String, dynamic>{...rawJson}
       ..remove('owners')
       ..remove('members');
-    final org = Organization.fromJson(result);
+    final Organization org = Organization.fromJson(result);
 
     final List<Future<User>> futureOwners =
         (rawJson['owners'].cast<DocumentReference>() as List<DocumentReference>)

--- a/lib/repositories/user_repository.dart
+++ b/lib/repositories/user_repository.dart
@@ -82,6 +82,7 @@ class UserRepository extends UserRepositoryInterface {
     await auth.signOut();
   }
 
+  @override
   Future<DocumentReference> getUserRef(String userId) async {
     return firestore.collection(collectionName).document(userId);
   }

--- a/lib/repositories/user_repository.dart
+++ b/lib/repositories/user_repository.dart
@@ -93,7 +93,7 @@ class UserRepository extends UserRepositoryInterface {
 
   @override
   Future<User> getUser(String userId) async {
-    final snapshot =
+    final DocumentSnapshot snapshot =
         await firestore.collection(collectionName).document(userId).get();
     return User.fromJson(snapshot.data);
   }

--- a/lib/repositories/user_repository.dart
+++ b/lib/repositories/user_repository.dart
@@ -90,4 +90,11 @@ class UserRepository extends UserRepositoryInterface {
   Future<User> fromUserRef(DocumentReference userRef) async {
     return User.fromJson((await userRef.get()).data);
   }
+
+  @override
+  Future<User> getUser(String userId) async {
+    final snapshot =
+        await firestore.collection(collectionName).document(userId).get();
+    return User.fromJson(snapshot.data);
+  }
 }

--- a/lib/repositories/user_repository.dart
+++ b/lib/repositories/user_repository.dart
@@ -1,11 +1,10 @@
 import 'dart:async';
 
-import 'package:meta/meta.dart';
-
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
-
+import 'package:meta/meta.dart';
 import 'package:shiftend/models/models.dart';
+
 import 'interfaces/user_repository_interface.dart';
 
 class UserRepository extends UserRepositoryInterface {
@@ -81,5 +80,14 @@ class UserRepository extends UserRepositoryInterface {
   @override
   Future<void> signOut() async {
     await auth.signOut();
+  }
+
+  Future<DocumentReference> getUserRef(String userId) async {
+    return firestore.collection(collectionName).document(userId);
+  }
+
+  @override
+  Future<User> fromUserRef(DocumentReference userRef) async {
+    return User.fromJson((await userRef.get()).data);
   }
 }


### PR DESCRIPTION
## 対応するissue
- close #58 
- 
## 概要
DBにuserIdを保存して参照していたものを参照型に置き換えた．

## 変更点・追加点
- OrganizationRepositoryの引数にUserRepositoryを必須にした
- ShiftRepositoryの引数にUserRepositoryを必須にした．
- batchOrgにあるShiftとはスキーマを変えたので，batchOrgを見に行こうとするとエラーが発生します．
- batchOrgからrefOrgに一時的に変更しました．
- 組織とシフトにスキーマ変更が発生しているので，debug pageから組織を作り直したり，シフトを作成し直したりすると，良いです．
## 使い方/バグ再現手順
- debug pageで今まで通り通信ができ，DBに保存ができていることを確認する．
- 
- 
## スクリーンショット等
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## コードレビューチェックリスト
- [ ] 仕様と実装はあっている
- [ ] 無意味なロジックがない
- [ ] DRYを守っている
- [ ] テストが適切に書かれている
- [ ] メソッド名、変数名などが適切
- [ ] コーディングルールを守れている
- [ ] メソッドからは予想できない副作用が含まれていない

チェックした人：
## その他特記事項
