### PR TITLE
fix pubspec.yaml for upgrade flutter version(1.20.2)

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -53,7 +53,7 @@ jobs:
           java-version: "12.x"
       - uses: subosito/flutter-action@v1
         with:
-          flutter-version: '1.20.1' # you can use 1.12
+          flutter-version: '1.20.2' # you can use 1.12
           channel: "stable"
       - run: flutter pub get
       - name: prepare google-services.json

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -639,4 +639,4 @@ packages:
     version: "2.2.1"
 sdks:
   dart: ">=2.9.0-14.0.dev <3.0.0"
-  flutter: "1.20.1"
+  flutter: "1.20.2"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  flutter: 1.20.1
+  flutter: 1.20.2
   sdk: ">=2.7.0 <3.0.0"
 
 dependencies:


### PR DESCRIPTION
## 対応するissue
- [#66｜flutter version上げ1.20.1→1.20.2](https://github.com/team-x-fun/shiftend/issues/66)
- 
## 概要

flutterを最新の1.20.2にあわせるようにpubspec.yamlを書き換えた

## 変更点・追加点
- 
- 
- 
## 使い方/バグ再現手順
- 
- 
- 
## スクリーンショット等
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## コードレビューチェックリスト
- [ ] 仕様と実装はあっている
- [ ] 無意味なロジックがない
- [ ] DRYを守っている
- [ ] テストが適切に書かれている
- [ ] メソッド名、変数名などが適切
- [ ] コーディングルールを守れている
- [ ] メソッドからは予想できない副作用が含まれていない

チェックした人：
## その他特記事項
