### PR TITLE
強制ログイン画面を外す

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -67,6 +67,7 @@ class _MainState extends State<Main> {
     CalendarPage(),
     MemberPage(),
     SettingPage(),
+    LoginPage(),
     DebugPage(),
   ];
 
@@ -81,10 +82,13 @@ class _MainState extends State<Main> {
       const BottomNavigationBarItem(
           icon: Icon(Icons.settings), title: Text('設定')),
       const BottomNavigationBarItem(
+          icon: Icon(Icons.account_circle), title: Text('ログインページ')),
+      const BottomNavigationBarItem(
           icon: Icon(Icons.settings), title: Text('debug')),
     ];
     if (!isLogin) {
-      return LoginPage();
+      // TODO: ログインしていないときは，ログインページに飛ばす
+      // return LoginPage();
     }
     return MultiProvider(
       providers: [


### PR DESCRIPTION
## 対応するissue
- 
- 
## 概要
- いちいち強制的にログイン画面を外すのは不便だったため，bottombarにログインページを追加した

## 変更点・追加点
- 
- 
- 
## 使い方/バグ再現手順
- 
- 
- 
## スクリーンショット等
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## コードレビューチェックリスト
- [ ] 仕様と実装はあっている
- [ ] 無意味なロジックがない
- [ ] DRYを守っている
- [ ] テストが適切に書かれている
- [ ] メソッド名、変数名などが適切
- [ ] コーディングルールを守れている
- [ ] メソッドからは予想できない副作用が含まれていない

チェックした人：
## その他特記事項
