### PR TITLE
feat: ログインユーザのシフト希望を表示

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,7 @@ import 'package:shiftend/pages/member/member_page.dart';
 import 'package:shiftend/repositories/mocks/shift_repository_mock.dart';
 import 'package:shiftend/repositories/mocks/user_repository_mock.dart';
 import 'package:shiftend/repositories/shift_repository.dart';
+import 'package:shiftend/repositories/shift_request_repository.dart';
 import 'package:shiftend/repositories/user_repository.dart';
 
 Future main() async {
@@ -41,6 +42,13 @@ class MyApp extends StatelessWidget {
         Provider<ShiftRepositoryMock>.value(
           value: ShiftRepositoryMock(userRepo: UserRepositoryMock()),
         ),
+        Provider<ShiftRequestRepository>.value(
+            value: ShiftRequestRepository(
+          userRepo: UserRepository(
+              firestore: FirebaseFirestore.instance,
+              auth: FirebaseAuth.instance),
+          firestore: FirebaseFirestore.instance,
+        )),
         Provider<UserRepository>.value(
           value: UserRepository(
               firestore: FirebaseFirestore.instance,

--- a/lib/pages/calendar/calendar_page.dart
+++ b/lib/pages/calendar/calendar_page.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:shiftend/models/notifier_state.dart';
 import 'package:shiftend/pages/calendar/calendar_state.dart';
-import 'package:shiftend/pages/calendar/widgets/calendar_desired_shift_widget.dart';
+import 'package:shiftend/pages/calendar/widgets/calendar_shift_request_widget.dart';
 import 'package:shiftend/pages/calendar/widgets/calendar_list_tab_widget.dart';
 import 'package:shiftend/pages/calendar/widgets/calendar_list_widget.dart';
 import 'package:shiftend/pages/calendar/widgets/calendar_widget.dart';
@@ -19,7 +19,7 @@ class CalendarPage extends StatefulWidget {
 
 final tabs = [
   CalendarBottomTab(label: '出勤情報', body: CalendarListWidget()),
-  CalendarBottomTab(label: 'あなたの出勤希望', body: CalendarDesiredShiftWidget()),
+  CalendarBottomTab(label: 'あなたの出勤希望', body: CalendarShiftRequestWidget()),
 ];
 
 class _CalendarPageState extends State<CalendarPage>

--- a/lib/pages/calendar/calendar_state.dart
+++ b/lib/pages/calendar/calendar_state.dart
@@ -11,5 +11,6 @@ abstract class CalendarState with _$CalendarState {
     Map<DateTime, List<Shift>> shifts,
     DateTime selectedDate,
     @Default(<Shift>[]) List<Shift> selectedShifts,
+    @Default(<Shift>[]) List<Shift> loggedinUserRequestedShifts,
   }) = _CalendarState;
 }

--- a/lib/pages/calendar/calendar_state.freezed.dart
+++ b/lib/pages/calendar/calendar_state.freezed.dart
@@ -16,12 +16,14 @@ class _$CalendarStateTearOff {
       {NotifierState notifierState = NotifierState.initial,
       Map<DateTime, List<Shift>> shifts,
       DateTime selectedDate,
-      List<Shift> selectedShifts = const <Shift>[]}) {
+      List<Shift> selectedShifts = const <Shift>[],
+      List<Shift> loggedinUserRequestedShifts = const <Shift>[]}) {
     return _CalendarState(
       notifierState: notifierState,
       shifts: shifts,
       selectedDate: selectedDate,
       selectedShifts: selectedShifts,
+      loggedinUserRequestedShifts: loggedinUserRequestedShifts,
     );
   }
 }
@@ -34,6 +36,7 @@ mixin _$CalendarState {
   Map<DateTime, List<Shift>> get shifts;
   DateTime get selectedDate;
   List<Shift> get selectedShifts;
+  List<Shift> get loggedinUserRequestedShifts;
 
   $CalendarStateCopyWith<CalendarState> get copyWith;
 }
@@ -46,7 +49,8 @@ abstract class $CalendarStateCopyWith<$Res> {
       {NotifierState notifierState,
       Map<DateTime, List<Shift>> shifts,
       DateTime selectedDate,
-      List<Shift> selectedShifts});
+      List<Shift> selectedShifts,
+      List<Shift> loggedinUserRequestedShifts});
 }
 
 class _$CalendarStateCopyWithImpl<$Res>
@@ -63,6 +67,7 @@ class _$CalendarStateCopyWithImpl<$Res>
     Object shifts = freezed,
     Object selectedDate = freezed,
     Object selectedShifts = freezed,
+    Object loggedinUserRequestedShifts = freezed,
   }) {
     return _then(_value.copyWith(
       notifierState: notifierState == freezed
@@ -77,6 +82,9 @@ class _$CalendarStateCopyWithImpl<$Res>
       selectedShifts: selectedShifts == freezed
           ? _value.selectedShifts
           : selectedShifts as List<Shift>,
+      loggedinUserRequestedShifts: loggedinUserRequestedShifts == freezed
+          ? _value.loggedinUserRequestedShifts
+          : loggedinUserRequestedShifts as List<Shift>,
     ));
   }
 }
@@ -91,7 +99,8 @@ abstract class _$CalendarStateCopyWith<$Res>
       {NotifierState notifierState,
       Map<DateTime, List<Shift>> shifts,
       DateTime selectedDate,
-      List<Shift> selectedShifts});
+      List<Shift> selectedShifts,
+      List<Shift> loggedinUserRequestedShifts});
 }
 
 class __$CalendarStateCopyWithImpl<$Res>
@@ -110,6 +119,7 @@ class __$CalendarStateCopyWithImpl<$Res>
     Object shifts = freezed,
     Object selectedDate = freezed,
     Object selectedShifts = freezed,
+    Object loggedinUserRequestedShifts = freezed,
   }) {
     return _then(_CalendarState(
       notifierState: notifierState == freezed
@@ -124,6 +134,9 @@ class __$CalendarStateCopyWithImpl<$Res>
       selectedShifts: selectedShifts == freezed
           ? _value.selectedShifts
           : selectedShifts as List<Shift>,
+      loggedinUserRequestedShifts: loggedinUserRequestedShifts == freezed
+          ? _value.loggedinUserRequestedShifts
+          : loggedinUserRequestedShifts as List<Shift>,
     ));
   }
 }
@@ -133,9 +146,11 @@ class _$_CalendarState implements _CalendarState {
       {this.notifierState = NotifierState.initial,
       this.shifts,
       this.selectedDate,
-      this.selectedShifts = const <Shift>[]})
+      this.selectedShifts = const <Shift>[],
+      this.loggedinUserRequestedShifts = const <Shift>[]})
       : assert(notifierState != null),
-        assert(selectedShifts != null);
+        assert(selectedShifts != null),
+        assert(loggedinUserRequestedShifts != null);
 
   @JsonKey(defaultValue: NotifierState.initial)
   @override
@@ -147,10 +162,13 @@ class _$_CalendarState implements _CalendarState {
   @JsonKey(defaultValue: const <Shift>[])
   @override
   final List<Shift> selectedShifts;
+  @JsonKey(defaultValue: const <Shift>[])
+  @override
+  final List<Shift> loggedinUserRequestedShifts;
 
   @override
   String toString() {
-    return 'CalendarState(notifierState: $notifierState, shifts: $shifts, selectedDate: $selectedDate, selectedShifts: $selectedShifts)';
+    return 'CalendarState(notifierState: $notifierState, shifts: $shifts, selectedDate: $selectedDate, selectedShifts: $selectedShifts, loggedinUserRequestedShifts: $loggedinUserRequestedShifts)';
   }
 
   @override
@@ -167,7 +185,12 @@ class _$_CalendarState implements _CalendarState {
                     .equals(other.selectedDate, selectedDate)) &&
             (identical(other.selectedShifts, selectedShifts) ||
                 const DeepCollectionEquality()
-                    .equals(other.selectedShifts, selectedShifts)));
+                    .equals(other.selectedShifts, selectedShifts)) &&
+            (identical(other.loggedinUserRequestedShifts,
+                    loggedinUserRequestedShifts) ||
+                const DeepCollectionEquality().equals(
+                    other.loggedinUserRequestedShifts,
+                    loggedinUserRequestedShifts)));
   }
 
   @override
@@ -176,7 +199,8 @@ class _$_CalendarState implements _CalendarState {
       const DeepCollectionEquality().hash(notifierState) ^
       const DeepCollectionEquality().hash(shifts) ^
       const DeepCollectionEquality().hash(selectedDate) ^
-      const DeepCollectionEquality().hash(selectedShifts);
+      const DeepCollectionEquality().hash(selectedShifts) ^
+      const DeepCollectionEquality().hash(loggedinUserRequestedShifts);
 
   @override
   _$CalendarStateCopyWith<_CalendarState> get copyWith =>
@@ -188,7 +212,8 @@ abstract class _CalendarState implements CalendarState {
       {NotifierState notifierState,
       Map<DateTime, List<Shift>> shifts,
       DateTime selectedDate,
-      List<Shift> selectedShifts}) = _$_CalendarState;
+      List<Shift> selectedShifts,
+      List<Shift> loggedinUserRequestedShifts}) = _$_CalendarState;
 
   @override
   NotifierState get notifierState;
@@ -198,6 +223,8 @@ abstract class _CalendarState implements CalendarState {
   DateTime get selectedDate;
   @override
   List<Shift> get selectedShifts;
+  @override
+  List<Shift> get loggedinUserRequestedShifts;
   @override
   _$CalendarStateCopyWith<_CalendarState> get copyWith;
 }

--- a/lib/pages/calendar/calendar_state_controller.dart
+++ b/lib/pages/calendar/calendar_state_controller.dart
@@ -53,7 +53,6 @@ class CalendarStateController extends StateNotifier<CalendarState>
   Future<void> fetchLoggedinUserRequestedShifts(DateTime date) async {
     final requestedShifts =
         await shiftRequestRepository.getShifts('refOrg', date);
-    print('controller ${requestedShifts[date]}');
 
     state = state.copyWith(
         loggedinUserRequestedShifts:

--- a/lib/pages/calendar/calendar_state_controller.dart
+++ b/lib/pages/calendar/calendar_state_controller.dart
@@ -3,6 +3,7 @@ import 'package:shiftend/models/models.dart';
 import 'package:shiftend/models/notifier_state.dart';
 import 'package:shiftend/pages/calendar/calendar_state.dart';
 import 'package:shiftend/repositories/mocks/shift_repository_mock.dart';
+import 'package:shiftend/repositories/shift_request_repository.dart';
 import 'package:shiftend/repositories/shift_repository.dart';
 import 'package:state_notifier/state_notifier.dart';
 
@@ -13,6 +14,9 @@ class CalendarStateController extends StateNotifier<CalendarState>
   ShiftRepository get shiftRepository => read<ShiftRepository>();
 
   ShiftRepositoryMock get shiftRepositoryMock => read<ShiftRepositoryMock>();
+
+  ShiftRequestRepository get shiftRequestRepository =>
+      read<ShiftRequestRepository>();
   final _dateFormatter = DateFormat('yyyy-MM-dd');
 
   @override
@@ -44,5 +48,15 @@ class CalendarStateController extends StateNotifier<CalendarState>
   void onDaySelected(DateTime date, List<Shift> shifts) {
     state = state.copyWith(selectedDate: date);
     state = state.copyWith(selectedShifts: shifts);
+  }
+
+  Future<void> fetchLoggedinUserRequestedShifts(DateTime date) async {
+    final requestedShifts =
+        await shiftRequestRepository.getShifts('refOrg', date);
+    print('controller ${requestedShifts[date]}');
+
+    state = state.copyWith(
+        loggedinUserRequestedShifts:
+            requestedShifts[DateTime(date.year, date.month, date.day)]);
   }
 }

--- a/lib/pages/calendar/calendar_state_controller.dart
+++ b/lib/pages/calendar/calendar_state_controller.dart
@@ -5,6 +5,7 @@ import 'package:shiftend/pages/calendar/calendar_state.dart';
 import 'package:shiftend/repositories/mocks/shift_repository_mock.dart';
 import 'package:shiftend/repositories/shift_request_repository.dart';
 import 'package:shiftend/repositories/shift_repository.dart';
+import 'package:shiftend/repositories/user_repository.dart';
 import 'package:state_notifier/state_notifier.dart';
 
 class CalendarStateController extends StateNotifier<CalendarState>
@@ -17,6 +18,9 @@ class CalendarStateController extends StateNotifier<CalendarState>
 
   ShiftRequestRepository get shiftRequestRepository =>
       read<ShiftRequestRepository>();
+
+  UserRepository get userRepository => read<UserRepository>();
+
   final _dateFormatter = DateFormat('yyyy-MM-dd');
 
   @override
@@ -53,9 +57,11 @@ class CalendarStateController extends StateNotifier<CalendarState>
   Future<void> fetchLoggedinUserRequestedShifts(DateTime date) async {
     final requestedShifts =
         await shiftRequestRepository.getShifts('refOrg', date);
-
+    final currentUser = await userRepository.getCurrentUser();
     state = state.copyWith(
         loggedinUserRequestedShifts:
-            requestedShifts[DateTime(date.year, date.month, date.day)]);
+            requestedShifts[DateTime(date.year, date.month, date.day)]
+                .where((shift) => shift.user.id == currentUser.id)
+                .toList());
   }
 }

--- a/lib/pages/calendar/widgets/calendar_shift_request_widget.dart
+++ b/lib/pages/calendar/widgets/calendar_shift_request_widget.dart
@@ -1,13 +1,17 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 import 'package:shiftend/models/shift/shift.dart';
+import 'package:shiftend/pages/calendar/calendar_state.dart';
 import 'package:shiftend/pages/calendar/widgets/calendar_list_item_widget.dart';
 
-class CalendarDesiredShiftWidget extends StatelessWidget {
+class CalendarShiftRequestWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final List<Widget> listItems = [];
-    final List<Shift> shifts = [];
+    final List<Shift> shifts = Provider.of<CalendarState>(context, listen: true)
+        .loggedinUserRequestedShifts;
+    print('request $shifts');
     if (shifts.isNotEmpty) {
       shifts.forEach(
         (shift) {

--- a/lib/pages/calendar/widgets/calendar_shift_request_widget.dart
+++ b/lib/pages/calendar/widgets/calendar_shift_request_widget.dart
@@ -11,7 +11,6 @@ class CalendarShiftRequestWidget extends StatelessWidget {
     final List<Widget> listItems = [];
     final List<Shift> shifts = Provider.of<CalendarState>(context, listen: true)
         .loggedinUserRequestedShifts;
-    print('request $shifts');
     if (shifts.isNotEmpty) {
       shifts.forEach(
         (shift) {

--- a/lib/pages/calendar/widgets/calendar_widget.dart
+++ b/lib/pages/calendar/widgets/calendar_widget.dart
@@ -110,6 +110,8 @@ class CalendarWidget extends StatelessWidget {
       onDaySelected: (date, attendees) {
         Provider.of<CalendarStateController>(context, listen: false)
             .onDaySelected(date, attendees.cast<Shift>());
+        Provider.of<CalendarStateController>(context, listen: false)
+            .fetchLoggedinUserRequestedShifts(date);
         animationController.forward(from: 0);
       },
       onVisibleDaysChanged: (first, last, format) {


### PR DESCRIPTION
## 対応するissue
- #64 

## 概要
ログインユーザの希望勤務日を表示した

## 使い方/バグ再現手順
- `owner@example.com` でログイン
- 2020/08/20をタップして「あなたの勤務希望」が表示されることを確認

## スクリーンショット等
スクショ|
---|
<img width="394" alt="shift-requests" src="https://user-images.githubusercontent.com/18653847/93725927-14531980-fbee-11ea-806e-5f826e51cfdc.png">|

## コードレビューチェックリスト
- [ ] 仕様と実装はあっている
- [ ] 無意味なロジックがない
- [ ] DRYを守っている
- [ ] テストが適切に書かれている
- [ ] メソッド名、変数名などが適切
- [ ] コーディングルールを守れている
- [ ] メソッドからは予想できない副作用が含まれていない

チェックした人：
## その他特記事項
