### PR TITLE
add ios build

### DIFF
--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -41,10 +41,40 @@ jobs:
           npm test
         env:
           CI: true
-  build:
+  analyze:
     # The type of runner that the job will run on
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     needs: prepare
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-java@v1
+        with:
+          java-version: "12.x"
+      - uses: subosito/flutter-action@v1
+        with:
+          flutter-version: "1.20.x" # you can use 1.20
+          channel: "stable"
+      - run: flutter pub get
+      - name: check format
+        run: scripts/check_format.sh
+      - run: flutter analyze
+      # - run: flutter test
+      - name: Slack Notification
+        uses: homoluctus/slatify@master
+        if: always()
+        with:
+          type: ${{ job.status }}
+          job_name: "*Analyze and format Check*"
+          mention: "here"
+          mention_if: "failure"
+          commit: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          url: ${{ secrets.SLACK_WEBHOOK }}
+  build-android:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    needs: analyze
 
     steps:
       - uses: actions/checkout@v1
@@ -59,23 +89,46 @@ jobs:
       - name: prepare google-services.json
         env:
           GOOGLE_SERVICES_BASE64: ${{ secrets.GOOGLE_SERVICES_BASE64 }}
-        run: echo $GOOGLE_SERVICES_BASE64 | base64 --decode > ${GITHUB_WORKSPACE}/android/app/google-services.json
+        run: echo $GOOGLE_SERVICES_BASE64 | base64 --decode --ignore-garbage > ${GITHUB_WORKSPACE}/android/app/google-services.json
+      - run: flutter build apk
+      - name: Slack Notification
+        uses: homoluctus/slatify@master
+        if: always()
+        with:
+          type: ${{ job.status }}
+          job_name: "*android Build Check*"
+          mention: "here"
+          mention_if: "failure"
+          commit: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          url: ${{ secrets.SLACK_WEBHOOK }}
+
+  build-ios:
+    # The type of runner that the job will run on
+    runs-on: macos-latest
+    needs: analyze
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-java@v1
+        with:
+          java-version: "12.x"
+      - uses: subosito/flutter-action@v1
+        with:
+          flutter-version: "1.20.x" # you can use 1.20
+          channel: "stable"
+      - run: flutter pub get
       - name: prepare GoogleService-Info.plist
         env:
           GOOGLE_SERVICE_INFO_BASE64: ${{ secrets.GOOGLE_SERVICE_INFO_BASE64}}
         run: echo $GOOGLE_SERVICE_INFO_BASE64 | base64 --decode > ${GITHUB_WORKSPACE}/ios/Runner/GoogleService-Info.plist
-      - name: check format
-        run: scripts/check_format.sh
-      - run: flutter analyze
-      # - run: flutter test
-      - run: flutter build apk
       - run: flutter build ios --release --no-codesign
       - name: Slack Notification
         uses: homoluctus/slatify@master
         if: always()
         with:
           type: ${{ job.status }}
-          job_name: "*Build and Debug Check*"
+          job_name: "*ios Build Check*"
           mention: "here"
           mention_if: "failure"
           commit: true

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -53,7 +53,7 @@ jobs:
           java-version: "12.x"
       - uses: subosito/flutter-action@v1
         with:
-          flutter-version: "1.20.2" # you can use 1.12
+          flutter-version: "1.20.x" # you can use 1.20
           channel: "stable"
       - run: flutter pub get
       - name: prepare google-services.json

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -43,7 +43,7 @@ jobs:
           CI: true
   build:
     # The type of runner that the job will run on
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     needs: prepare
 
     steps:
@@ -53,18 +53,23 @@ jobs:
           java-version: "12.x"
       - uses: subosito/flutter-action@v1
         with:
-          flutter-version: '1.20.2' # you can use 1.12
+          flutter-version: "1.20.2" # you can use 1.12
           channel: "stable"
       - run: flutter pub get
       - name: prepare google-services.json
         env:
           GOOGLE_SERVICES_BASE64: ${{ secrets.GOOGLE_SERVICES_BASE64 }}
-        run: echo $GOOGLE_SERVICES_BASE64 | base64 --decode --ignore-garbage > ${GITHUB_WORKSPACE}/android/app/google-services.json
+        run: echo $GOOGLE_SERVICES_BASE64 | base64 --decode > ${GITHUB_WORKSPACE}/android/app/google-services.json
+      - name: prepare GoogleService-Info.plist
+        env:
+          GOOGLE_SERVICE_INFO_BASE64: ${{ secrets.GOOGLE_SERVICE_INFO_BASE64}}
+        run: echo $GOOGLE_SERVICE_INFO_BASE64 | base64 --decode > ${GITHUB_WORKSPACE}/ios/Runner/GoogleService-Info.plist
       - name: check format
         run: scripts/check_format.sh
       - run: flutter analyze
       # - run: flutter test
       - run: flutter build apk
+      - run: flutter build ios --release --no-codesign
       - name: Slack Notification
         uses: homoluctus/slatify@master
         if: always()


### PR DESCRIPTION
## 対応するissue
- #89 
- 
## 概要
ciでビルドするときに，iosのビルドも走らせる．
jobを複数に分けた，
- anlyze (formatチェックや，flutter analyze)
- build-android
- build-ios

でパラレルに実行するように修正．
それぞれで，結果をslack通知

## 変更点・追加点
- secretsにGOOGLE_SERVICE_INFO_BASE64としてGoogleService-Info.plistをbase64でエンコードしたものを追加
- 
- 
## 使い方/バグ再現手順
- 
- 
- 
## スクリーンショット等
Before | After
:--: | :--:
<img src="" width="300" /> | <img src="" width="300" />

## コードレビューチェックリスト
- [ ] 仕様と実装はあっている
- [ ] 無意味なロジックがない
- [ ] DRYを守っている
- [ ] テストが適切に書かれている
- [ ] メソッド名、変数名などが適切
- [ ] コーディングルールを守れている
- [ ] メソッドからは予想できない副作用が含まれていない

チェックした人：
## その他特記事項
