### PR TITLE
requestShifts[today]がnullのときのハンドリング

### DIFF
--- a/lib/pages/calendar/calendar_state_controller.dart
+++ b/lib/pages/calendar/calendar_state_controller.dart
@@ -75,10 +75,14 @@ class CalendarStateController extends StateNotifier<CalendarState>
     final requestedShifts =
         await shiftRequestRepository.getShifts(loginState.selectedOrg.id, date);
     final currentUser = await userRepository.getCurrentUser();
-    state = state.copyWith(
-        loggedinUserRequestedShifts:
-            requestedShifts[DateTime(date.year, date.month, date.day)]
-                .where((shift) => shift.user.id == currentUser.id)
-                .toList());
+    final today = DateTime(date.year, date.month, date.day);
+    if (requestedShifts[today] == null) {
+      state = state.copyWith(loggedinUserRequestedShifts: <Shift>[]);
+    } else {
+      state = state.copyWith(
+          loggedinUserRequestedShifts: requestedShifts[today]
+              .where((shift) => shift.user.id == currentUser.id)
+              .toList());
+    }
   }
 }


### PR DESCRIPTION
## 対応する issue

-
-

## 概要

## 変更点・追加点

-
-
-

## 使い方/バグ再現手順

- シフト希望があるところをタップしたあと，シフト希望が出されていない日をタップするとバグる．
-
-

## スクリーンショット等
こんな感じで，実際には，シフト希望出されてないけど，requestShifts[today]がnullだとstateの更新に失敗して，前いたところのシフト希望の状態が残ってしまう．
|           Before           |           After            |
| :------------------------: | :------------------------: |
| <img src="https://user-images.githubusercontent.com/15919309/93863266-45bb0a80-fcfe-11ea-9323-a9d8f1f38306.png" width="300" /> | <img src="https://user-images.githubusercontent.com/15919309/93863315-54092680-fcfe-11ea-80f0-8444a0352c49.png" width="300" /> |

チェックした人：

## その他特記事項
