### PR TITLE
組織設定画面開いたら赤くなるのをなおした

### DIFF
--- a/lib/pages/setting/setting_org/setting_org_page.dart
+++ b/lib/pages/setting/setting_org/setting_org_page.dart
@@ -61,9 +61,12 @@ class SettingOrgPage extends StatelessWidget {
         ),
       );
     });
+    final holidays = context
+        .select<SettingOrgState, List<Holiday>>((state) => state.holidays);
     if (context.select<SettingOrgState, NotifierState>(
-            (state) => state.notifierState) ==
-        NotifierState.loaded) {
+                (state) => state.notifierState) ==
+            NotifierState.loaded &&
+        holidays.isNotEmpty) {
       _items
         ..add(
           Container(
@@ -83,11 +86,6 @@ class SettingOrgPage extends StatelessWidget {
             },
           ),
         );
-    }
-
-    final holidays = context
-        .select<SettingOrgState, List<Holiday>>((state) => state.holidays);
-    if (holidays.isNotEmpty) {
       holidays.forEach((holiday) {
         _items.add(ListTile(
           title: Text(

--- a/lib/pages/setting/setting_org/setting_org_state_controller.dart
+++ b/lib/pages/setting/setting_org/setting_org_state_controller.dart
@@ -24,6 +24,7 @@ class SettingOrgStateController extends StateNotifier<SettingOrgState>
 
   Future<void> fetchOrganizationMembers() async {
     if (loginState.selectedOrg == null) {
+      state = state.copyWith(notifierState: NotifierState.loaded);
       return;
     }
     return organizationRepository
@@ -37,13 +38,13 @@ class SettingOrgStateController extends StateNotifier<SettingOrgState>
   }
 
   void fetchHolidays() {
-    if (loginState.selectedOrg.id != null) {
-      organizationRepository
-          .getHolidays(loginState.selectedOrg.id)
-          .then((value) {
-        state = state.copyWith(
-            notifierState: NotifierState.loaded, holidays: value);
-      });
+    if (loginState.selectedOrg == null) {
+      state = state.copyWith(notifierState: NotifierState.loaded);
+      return;
     }
+    organizationRepository.getHolidays(loginState.selectedOrg.id).then((value) {
+      state =
+          state.copyWith(notifierState: NotifierState.loaded, holidays: value);
+    });
   }
 }


### PR DESCRIPTION
## 対応する issue

- close #124 

## 概要

## 変更点・追加点

- 組織設定画面でそもそも組織入ってなかったりしたら休日の追加とか出さないようにした
-
-

## 使い方/バグ再現手順

-
-
-

## スクリーンショット等

|           Before           |           After            |
| :------------------------: | :------------------------: |
| <img src="" width="300" /> | <img src="" width="300" /> |

チェックした人：

## その他特記事項
