### PR TITLE
サインアウトしたときに，LoginStateの組織データのリセットを掛ける修正

### DIFF
--- a/lib/models/organization/organization.dart
+++ b/lib/models/organization/organization.dart
@@ -12,8 +12,15 @@ part 'organization.g.dart';
 abstract class Organization with _$Organization {
   const factory Organization({
     String id,
-    @UserConverter() @JsonKey(name: 'owners') List<User> owners,
-    @UserConverter() @JsonKey(name: 'members') List<User> members,
+    @Default(<User>[])
+    @UserConverter()
+    @JsonKey(name: 'owners')
+        List<User> owners,
+    @Default(<User>[])
+    @UserConverter()
+    @JsonKey(name: 'members')
+        List<User> members,
+    @Default(<Holiday>[])
     @JsonKey(name: 'default_holidays')
     @HolidayConverter()
         List<Holiday> defaultHolidays,

--- a/lib/models/organization/organization.freezed.dart
+++ b/lib/models/organization/organization.freezed.dart
@@ -19,13 +19,13 @@ class _$OrganizationTearOff {
       {String id,
       @UserConverter()
       @JsonKey(name: 'owners')
-          List<User> owners,
+          List<User> owners = const <User>[],
       @UserConverter()
       @JsonKey(name: 'members')
-          List<User> members,
+          List<User> members = const <User>[],
       @JsonKey(name: 'default_holidays')
       @HolidayConverter()
-          List<Holiday> defaultHolidays,
+          List<Holiday> defaultHolidays = const <Holiday>[],
       @JsonKey(name: 'default_personnel')
           Personnel defaultPersonnel}) {
     return _Organization(
@@ -180,15 +180,18 @@ class _$_Organization with DiagnosticableTreeMixin implements _Organization {
       {this.id,
       @UserConverter()
       @JsonKey(name: 'owners')
-          this.owners,
+          this.owners = const <User>[],
       @UserConverter()
       @JsonKey(name: 'members')
-          this.members,
+          this.members = const <User>[],
       @JsonKey(name: 'default_holidays')
       @HolidayConverter()
-          this.defaultHolidays,
+          this.defaultHolidays = const <Holiday>[],
       @JsonKey(name: 'default_personnel')
-          this.defaultPersonnel});
+          this.defaultPersonnel})
+      : assert(owners != null),
+        assert(members != null),
+        assert(defaultHolidays != null);
 
   factory _$_Organization.fromJson(Map<String, dynamic> json) =>
       _$_$_OrganizationFromJson(json);

--- a/lib/pages/login/login_state.dart
+++ b/lib/pages/login/login_state.dart
@@ -8,7 +8,7 @@ abstract class LoginState with _$LoginState {
   const factory LoginState({
     @Default(false) bool isLogin,
     User currentUser,
-    List<Organization> orgs,
-    Organization selectedOrg,
+    @Default(<Organization>[]) List<Organization> orgs,
+    @Default(Organization()) Organization selectedOrg,
   }) = _LoginState;
 }

--- a/lib/pages/login/login_state.freezed.dart
+++ b/lib/pages/login/login_state.freezed.dart
@@ -15,8 +15,8 @@ class _$LoginStateTearOff {
   _LoginState call(
       {bool isLogin = false,
       User currentUser,
-      List<Organization> orgs,
-      Organization selectedOrg}) {
+      List<Organization> orgs = const <Organization>[],
+      Organization selectedOrg = const Organization()}) {
     return _LoginState(
       isLogin: isLogin,
       currentUser: currentUser,
@@ -145,16 +145,23 @@ class __$LoginStateCopyWithImpl<$Res> extends _$LoginStateCopyWithImpl<$Res>
 
 class _$_LoginState with DiagnosticableTreeMixin implements _LoginState {
   const _$_LoginState(
-      {this.isLogin = false, this.currentUser, this.orgs, this.selectedOrg})
-      : assert(isLogin != null);
+      {this.isLogin = false,
+      this.currentUser,
+      this.orgs = const <Organization>[],
+      this.selectedOrg = const Organization()})
+      : assert(isLogin != null),
+        assert(orgs != null),
+        assert(selectedOrg != null);
 
   @JsonKey(defaultValue: false)
   @override
   final bool isLogin;
   @override
   final User currentUser;
+  @JsonKey(defaultValue: const <Organization>[])
   @override
   final List<Organization> orgs;
+  @JsonKey(defaultValue: const Organization())
   @override
   final Organization selectedOrg;
 

--- a/lib/pages/login/login_state_controller.dart
+++ b/lib/pages/login/login_state_controller.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:shiftend/models/models.dart';
 import 'package:shiftend/repositories/organization_repository.dart';
 import 'package:shiftend/repositories/user_repository.dart';
@@ -29,11 +30,24 @@ class LoginStateController extends StateNotifier<LoginState> with LocatorMixin {
     state = state.copyWith(
       currentUser: await userRepository.getCurrentUser(),
     );
-    if (state.currentUser != null) {
+    if (state.currentUser.id != null) {
+      debugPrint('set orgs: currentUser.id = ${state.currentUser.id}');
       state = state.copyWith(
         orgs: await orgRepository.getOrganizations(state.currentUser.id),
       );
+      debugPrint('fetchLoginState: selectedOrg = ${state.selectedOrg}');
+      if (state.selectedOrg.id == null) {
+        debugPrint('fetchLoginState: set selectedOrg');
+        state = state.copyWith(selectedOrg: state.orgs.first);
+        debugPrint('fetchLoginState: selectedOrg = ${state.selectedOrg}');
+      }
+    } else {
+      state = state.copyWith(
+        orgs: <Organization>[],
+        selectedOrg: const Organization(),
+      );
     }
+    debugPrint('fetchLoginState: state = $state');
   }
 
   Future<void> register(String email, String password) async {

--- a/lib/pages/setting/setting_org/setting_org_state_controller.dart
+++ b/lib/pages/setting/setting_org/setting_org_state_controller.dart
@@ -17,16 +17,16 @@ class SettingOrgStateController extends StateNotifier<SettingOrgState>
   @override
   void initState() {
     state = state.copyWith(notifierState: NotifierState.loading);
-    fetchOrganizationMembers();
-    fetchHolidays();
+    if (loginState.selectedOrg.id == null) {
+      state = state.copyWith(notifierState: NotifierState.loaded);
+    } else {
+      fetchOrganizationMembers();
+      fetchHolidays();
+    }
     super.initState();
   }
 
   Future<void> fetchOrganizationMembers() async {
-    if (loginState.selectedOrg == null) {
-      state = state.copyWith(notifierState: NotifierState.loaded);
-      return;
-    }
     return organizationRepository
         .getOrganization(loginState.selectedOrg.id)
         .then((value) {
@@ -38,10 +38,6 @@ class SettingOrgStateController extends StateNotifier<SettingOrgState>
   }
 
   void fetchHolidays() {
-    if (loginState.selectedOrg == null) {
-      state = state.copyWith(notifierState: NotifierState.loaded);
-      return;
-    }
     organizationRepository.getHolidays(loginState.selectedOrg.id).then((value) {
       state =
           state.copyWith(notifierState: NotifierState.loaded, holidays: value);

--- a/lib/pages/user/user_page.dart
+++ b/lib/pages/user/user_page.dart
@@ -15,6 +15,8 @@ class UserPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final user = Provider.of<LoginState>(context, listen: true).currentUser;
+    debugPrint(
+        'UserPage#build: LoginState = ${Provider.of<LoginState>(context, listen: false)}');
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Colors.grey[100],

--- a/lib/pages/user/widgets/org_select_widget.dart
+++ b/lib/pages/user/widgets/org_select_widget.dart
@@ -7,6 +7,13 @@ import 'package:shiftend/pages/login/login_state_controller.dart';
 class OrgSelectWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
+    final orgs = Provider.of<LoginState>(context).orgs;
+    print('OrgSelectWidget build: orgs.length = ${orgs.length}');
+    print(
+        'OrgSelectWidget build: selectedOrg = ${Provider.of<LoginState>(context).selectedOrg}');
+    if (orgs.isEmpty) {
+      return const Center();
+    }
     return Center(
       child: DropdownButton<Organization>(
         value: Provider.of<LoginState>(context, listen: true).selectedOrg,

--- a/lib/repositories/organization_repository.dart
+++ b/lib/repositories/organization_repository.dart
@@ -62,6 +62,8 @@ class OrganizationRepository extends OrganizationRepositoryInterface {
     final Map<String, dynamic> result = <String, dynamic>{...rawJson}
       ..remove('owners')
       ..remove('members');
+    result['owners'] = <String>[];
+    result['members'] = <String>[];
     final Organization org = Organization.fromJson(result);
 
     final List<Future<User>> futureOwners =


### PR DESCRIPTION
## 対応する issue

- close #123｜ログアウトしたあとに，組織の設定で組織情報が見えてしまう．
-

## 概要

## 変更点・追加点

- LoginStateController#fetchLoginStateの条件分岐を色々かけて, ログインされていないときには，orgsとselectedOrgを削除,
- ログインしているときに，orgsを更新，かつselectedOrgがなかった場合，orgs.firstを選択
-

## 使い方/バグ再現手順

-
-
-

## スクリーンショット等

|           Before           |           After            |
| :------------------------: | :------------------------: |
| <img src="" width="300" /> | <img src="" width="300" /> |

チェックした人：

## その他特記事項
