### PR TITLE
updateのときの保存するjsonが間違えていたので修正

### DIFF
--- a/lib/repositories/organization_repository.dart
+++ b/lib/repositories/organization_repository.dart
@@ -15,11 +15,7 @@ class OrganizationRepository extends OrganizationRepositoryInterface {
 
   @override
   Future<void> create(Organization org) async {
-    final Map<String, dynamic> json = org.toJson()
-      ..remove('owners')
-      ..remove('members');
-    json['owners'] = await _getUsersRef(org.owners);
-    json['members'] = await _getUsersRef(org.members);
+    final json = await _toJson(org);
 
     await firestore.collection(collectionName).doc(org.id).set(json);
   }
@@ -47,7 +43,8 @@ class OrganizationRepository extends OrganizationRepositoryInterface {
 
   @override
   Future<void> update(Organization org) async {
-    await firestore.collection(collectionName).doc(org.id).update(org.toJson());
+    final json = await _toJson(org);
+    await firestore.collection(collectionName).doc(org.id).update(json);
   }
 
   Future<List<DocumentReference>> _getUsersRef(List<User> users) async {
@@ -78,6 +75,15 @@ class OrganizationRepository extends OrganizationRepositoryInterface {
         .toList();
     final List<User> members = await Future.wait(futureMembers);
     return org.copyWith(owners: owners, members: members);
+  }
+
+  Future<Map<String, dynamic>> _toJson(Organization org) async {
+    final Map<String, dynamic> json = org.toJson()
+      ..remove('owners')
+      ..remove('members');
+    json['owners'] = await _getUsersRef(org.owners);
+    json['members'] = await _getUsersRef(org.members);
+    return json;
   }
 
   @override


### PR DESCRIPTION
## 対応する issue

-
-

## 概要

Firestoreに保存する際にownersとmembersは，参照型にして保存する必要がある．
しかし，updateでは，Organization.toJsonでjson化したものをupdateをかけていた．
それだと，参照型ではなく実体がorganizationsに保存されてしまう．
そのため，新たにrepository用に_toJsonを実装．
_toJsonでは，OrganizationのList<User>から参照型になるように，データを集めて改めてjsonにする


## 変更点・追加点

-
-
-

## 使い方/バグ再現手順

-
-
-

## スクリーンショット等

|           Before           |           After            |
| :------------------------: | :------------------------: |
| <img src="" width="300" /> | <img src="" width="300" /> |

チェックした人：

## その他特記事項
