### PR TITLE
member listをfirebaseと接続

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,8 @@ import 'package:shiftend/pages/login/login_page.dart';
 import 'package:shiftend/pages/login/login_state.dart';
 import 'package:shiftend/pages/login/login_state_controller.dart';
 import 'package:shiftend/pages/member/member_page.dart';
+import 'package:shiftend/pages/member/member_state.dart';
+import 'package:shiftend/pages/member/member_state_controller.dart';
 import 'package:shiftend/pages/setting/setting_page.dart';
 import 'package:shiftend/pages/setting/setting_org/setting_org_state.dart';
 import 'package:shiftend/pages/setting/setting_org/setting_org_state_controller.dart';
@@ -119,6 +121,8 @@ class _MainState extends State<Main> {
         StateNotifierProvider<CalendarStateController, CalendarState>(
           create: (context) => CalendarStateController(),
         ),
+        StateNotifierProvider<MemberStateController, MemberState>(
+            create: (_) => MemberStateController()),
         StateNotifierProvider<SettingOrgStateController, SettingOrgState>(
           create: (context) => SettingOrgStateController(),
         ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -122,7 +122,8 @@ class _MainState extends State<Main> {
           create: (context) => CalendarStateController(),
         ),
         StateNotifierProvider<MemberStateController, MemberState>(
-            create: (_) => MemberStateController()),
+          create: (context) => MemberStateController(),
+        ),
         StateNotifierProvider<SettingOrgStateController, SettingOrgState>(
           create: (context) => SettingOrgStateController(),
         ),

--- a/lib/pages/member/member_detail.dart
+++ b/lib/pages/member/member_detail.dart
@@ -59,11 +59,12 @@ class MemberDetailPage extends StatelessWidget {
                           .changeLevel(member.user.id, v);
                     },
                     starCount: 5,
-                    rating: context
-                        .select<MemberState, List<Member>>(
-                            (state) => state.members)
-                        .firstWhere((m) => m.user.id == member.user.id)
-                        .level,
+                    rating: context.select<MemberState, double>((state) {
+                      logger.info('update rating');
+                      return state.members
+                          .firstWhere((m) => m.user.id == member.user.id)
+                          .level;
+                    }),
                     size: 30,
                     isReadOnly: false,
                     color: Colors.orange,

--- a/lib/pages/member/member_detail.dart
+++ b/lib/pages/member/member_detail.dart
@@ -13,6 +13,7 @@ class MemberDetailPage extends StatelessWidget {
   final Member member;
   @override
   Widget build(BuildContext context) {
+    logger.info('MemberDetailBuild');
     return Scaffold(
       appBar: AppBar(
         title: const Text(
@@ -53,11 +54,16 @@ class MemberDetailPage extends StatelessWidget {
                     allowHalfRating: false,
                     onRated: (v) {
                       logger.info('rating value -> $v');
-                      context.read<MemberStateController>().changeLevel(v);
+                      context
+                          .read<MemberStateController>()
+                          .changeLevel(member.user.id, v);
                     },
                     starCount: 5,
                     rating: context
-                        .select<MemberState, double>((state) => state.level),
+                        .select<MemberState, List<Member>>(
+                            (state) => state.members)
+                        .firstWhere((m) => m.user.id == member.user.id)
+                        .level,
                     size: 30,
                     isReadOnly: false,
                     color: Colors.orange,
@@ -68,7 +74,7 @@ class MemberDetailPage extends StatelessWidget {
               ListTile(
                 dense: true,
                 trailing: Text(
-                  '${context.select<MemberState, String>((state) => state.tel)}',
+                  '${member.user.email}',
                 ),
                 title: const Text('電話'),
               ),

--- a/lib/pages/member/member_detail.dart
+++ b/lib/pages/member/member_detail.dart
@@ -8,12 +8,14 @@ import 'package:shiftend/util/logger.dart';
 import 'package:smooth_star_rating/smooth_star_rating.dart';
 
 class MemberDetailPage extends StatelessWidget {
-  const MemberDetailPage(this.member);
+  const MemberDetailPage({this.id});
 
-  final Member member;
+  final String id;
   @override
   Widget build(BuildContext context) {
     logger.info('MemberDetailBuild');
+    final member = context.select<MemberState, Member>(
+        (state) => state.members.firstWhere((m) => m.user.id == id));
     return Scaffold(
       appBar: AppBar(
         title: const Text(

--- a/lib/pages/member/member_item.dart
+++ b/lib/pages/member/member_item.dart
@@ -11,13 +11,17 @@ import 'widgets/level_stars_widget.dart';
 
 class MemberItem extends StatelessWidget {
   const MemberItem({
-    this.member,
+    this.id,
   });
 
-  final Member member;
+  final String id;
 
   @override
   Widget build(BuildContext context) {
+    final member = context
+        .select<MemberState, List<Member>>((state) => state.members)
+        .firstWhere((m) => m.user.id == id);
+    logger.info('MemberItem build: ${member.user.id}');
     return ListTile(
       onTap: () {
         Navigator.of(context).push(
@@ -26,7 +30,7 @@ class MemberItem extends StatelessWidget {
                 StateNotifierProvider<MemberStateController, MemberState>.value(
               value: context.read<MemberStateController>(),
               child: MemberDetailPage(
-                member,
+                id: member.user.id,
               ),
             ),
           ),
@@ -34,10 +38,7 @@ class MemberItem extends StatelessWidget {
       },
       dense: true,
       trailing: LevelStars(
-        level: context
-            .select<MemberState, List<Member>>((state) => state.members)
-            .firstWhere((m) => m.user.id == member.user.id)
-            .level,
+        level: member.level,
       ),
       leading: Container(
         height: 50,

--- a/lib/pages/member/member_item.dart
+++ b/lib/pages/member/member_item.dart
@@ -18,7 +18,6 @@ class MemberItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    logger.info(context.select<MemberState, double>((state) => state.level));
     return ListTile(
       onTap: () {
         Navigator.of(context).push(
@@ -26,14 +25,19 @@ class MemberItem extends StatelessWidget {
             builder: (_) =>
                 StateNotifierProvider<MemberStateController, MemberState>.value(
               value: context.read<MemberStateController>(),
-              child: MemberDetailPage(member),
+              child: MemberDetailPage(
+                member,
+              ),
             ),
           ),
         );
       },
       dense: true,
       trailing: LevelStars(
-        level: context.select<MemberState, double>((state) => state.level),
+        level: context
+            .select<MemberState, List<Member>>((state) => state.members)
+            .firstWhere((m) => m.user.id == member.user.id)
+            .level,
       ),
       leading: Container(
         height: 50,

--- a/lib/pages/member/member_page.dart
+++ b/lib/pages/member/member_page.dart
@@ -5,13 +5,10 @@ import 'package:shiftend/pages/login/login_state.dart';
 import 'package:shiftend/pages/member/member_item.dart';
 import 'package:shiftend/pages/member/member_state.dart';
 import 'package:shiftend/pages/member/member_state_controller.dart';
-import 'package:shiftend/repositories/interfaces/interfaces.dart';
-import 'package:shiftend/repositories/mocks/organization_repository_mock.dart';
 import 'package:shiftend/models/models.dart';
 import 'package:provider/provider.dart';
 
 class MemberPage extends StatelessWidget {
-  final OrganizationRepositoryInterface orgRepo = OrganizationRepositoryMock();
   @override
   Widget build(BuildContext context) {
     final members = context

--- a/lib/pages/member/member_page.dart
+++ b/lib/pages/member/member_page.dart
@@ -1,11 +1,9 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_state_notifier/flutter_state_notifier.dart';
 import 'package:shiftend/pages/member/member_item.dart';
 import 'package:shiftend/pages/member/member_state.dart';
 import 'package:shiftend/models/models.dart';
 import 'package:provider/provider.dart';
-import 'package:shiftend/pages/member/member_state_controller.dart';
 import 'package:shiftend/util/logger.dart';
 
 class MemberPage extends StatelessWidget {

--- a/lib/pages/member/member_page.dart
+++ b/lib/pages/member/member_page.dart
@@ -1,17 +1,21 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_state_notifier/flutter_state_notifier.dart';
+import 'package:shiftend/pages/login/login_state.dart';
 import 'package:shiftend/pages/member/member_item.dart';
 import 'package:shiftend/pages/member/member_state.dart';
 import 'package:shiftend/pages/member/member_state_controller.dart';
 import 'package:shiftend/repositories/interfaces/interfaces.dart';
 import 'package:shiftend/repositories/mocks/organization_repository_mock.dart';
 import 'package:shiftend/models/models.dart';
+import 'package:provider/provider.dart';
 
 class MemberPage extends StatelessWidget {
   final OrganizationRepositoryInterface orgRepo = OrganizationRepositoryMock();
   @override
   Widget build(BuildContext context) {
+    final members = context
+        .select<LoginState, List<Member>>((state) => state.selectedOrg.members);
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Colors.white,
@@ -21,25 +25,15 @@ class MemberPage extends StatelessWidget {
           style: TextStyle(color: Colors.black),
         ),
       ),
-      body: FutureBuilder(
-        future: orgRepo.getOrganization('test_id'),
-        builder: (context, AsyncSnapshot<Organization> snapshot) {
-          if (snapshot.hasData) {
-            return ListView.builder(
-              itemCount: snapshot.data.members.length,
-              itemBuilder: (context, index) {
-                return StateNotifierProvider<MemberStateController,
-                    MemberState>(
-                  create: (_) => MemberStateController(),
-                  child: MemberItem(
-                    member: snapshot.data.members[index],
-                  ),
-                );
-              },
-            );
-          } else {
-            return const Center(child: CircularProgressIndicator());
-          }
+      body: ListView.builder(
+        itemCount: members.length,
+        itemBuilder: (context, index) {
+          return StateNotifierProvider<MemberStateController, MemberState>(
+            create: (_) => MemberStateController(),
+            child: MemberItem(
+              member: members[index],
+            ),
+          );
         },
       ),
     );

--- a/lib/pages/member/member_page.dart
+++ b/lib/pages/member/member_page.dart
@@ -4,10 +4,12 @@ import 'package:shiftend/pages/member/member_item.dart';
 import 'package:shiftend/pages/member/member_state.dart';
 import 'package:shiftend/models/models.dart';
 import 'package:provider/provider.dart';
+import 'package:shiftend/util/logger.dart';
 
 class MemberPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
+    logger.info('MemberPage build');
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Colors.white,
@@ -18,17 +20,16 @@ class MemberPage extends StatelessWidget {
         ),
       ),
       body: ListView.builder(
-        itemCount: context
-            .select<MemberState, List<Member>>((state) => state.members)
-            .length,
+        itemCount: context.select<MemberState, int>(
+          (state) => state.members.length,
+        ),
         itemBuilder: (context, index) {
           return Builder(
-            builder: (context) {
-              return MemberItem(
-                member: context.select<MemberState, List<Member>>(
-                    (state) => state.members)[index],
-              );
-            },
+            builder: (context) => MemberItem(
+              member: context.select<MemberState, Member>(
+                (state) => state.members[index],
+              ),
+            ),
           );
         },
       ),

--- a/lib/pages/member/member_page.dart
+++ b/lib/pages/member/member_page.dart
@@ -1,18 +1,13 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_state_notifier/flutter_state_notifier.dart';
-import 'package:shiftend/pages/login/login_state.dart';
 import 'package:shiftend/pages/member/member_item.dart';
 import 'package:shiftend/pages/member/member_state.dart';
-import 'package:shiftend/pages/member/member_state_controller.dart';
 import 'package:shiftend/models/models.dart';
 import 'package:provider/provider.dart';
 
 class MemberPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    final members = context
-        .select<LoginState, List<Member>>((state) => state.selectedOrg.members);
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Colors.white,
@@ -23,13 +18,17 @@ class MemberPage extends StatelessWidget {
         ),
       ),
       body: ListView.builder(
-        itemCount: members.length,
+        itemCount: context
+            .select<MemberState, List<Member>>((state) => state.members)
+            .length,
         itemBuilder: (context, index) {
-          return StateNotifierProvider<MemberStateController, MemberState>(
-            create: (_) => MemberStateController(),
-            child: MemberItem(
-              member: members[index],
-            ),
+          return Builder(
+            builder: (context) {
+              return MemberItem(
+                member: context.select<MemberState, List<Member>>(
+                    (state) => state.members)[index],
+              );
+            },
           );
         },
       ),

--- a/lib/pages/member/member_page.dart
+++ b/lib/pages/member/member_page.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_state_notifier/flutter_state_notifier.dart';
 import 'package:shiftend/pages/member/member_item.dart';
 import 'package:shiftend/pages/member/member_state.dart';
 import 'package:shiftend/models/models.dart';
 import 'package:provider/provider.dart';
+import 'package:shiftend/pages/member/member_state_controller.dart';
 import 'package:shiftend/util/logger.dart';
 
 class MemberPage extends StatelessWidget {
@@ -20,18 +22,16 @@ class MemberPage extends StatelessWidget {
         ),
       ),
       body: ListView.builder(
-        itemCount: context.select<MemberState, int>(
-          (state) => state.members.length,
+        itemCount:
+            context.select<MemberState, int>((state) => state.members.length),
+        itemBuilder: (_, index) => Builder(
+          builder: (context) => MemberItem(
+            id: context
+                .select<MemberState, Member>((state) => state.members[index])
+                .user
+                .id,
+          ),
         ),
-        itemBuilder: (context, index) {
-          return Builder(
-            builder: (context) => MemberItem(
-              member: context.select<MemberState, Member>(
-                (state) => state.members[index],
-              ),
-            ),
-          );
-        },
       ),
     );
   }

--- a/lib/pages/member/member_state.dart
+++ b/lib/pages/member/member_state.dart
@@ -1,12 +1,12 @@
 import 'package:flutter/foundation.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:shiftend/models/models.dart';
 
 part 'member_state.freezed.dart';
 
 @freezed
 abstract class MemberState with _$MemberState {
   const factory MemberState({
-    @Default(3) double level,
-    @Default('000-0000-0000') String tel,
+    List<Member> members,
   }) = _MemberState;
 }

--- a/lib/pages/member/member_state.freezed.dart
+++ b/lib/pages/member/member_state.freezed.dart
@@ -12,10 +12,9 @@ T _$identity<T>(T value) => value;
 class _$MemberStateTearOff {
   const _$MemberStateTearOff();
 
-  _MemberState call({double level = 3, String tel = '000-0000-0000'}) {
+  _MemberState call({List<Member> members}) {
     return _MemberState(
-      level: level,
-      tel: tel,
+      members: members,
     );
   }
 }
@@ -24,8 +23,7 @@ class _$MemberStateTearOff {
 const $MemberState = _$MemberStateTearOff();
 
 mixin _$MemberState {
-  double get level;
-  String get tel;
+  List<Member> get members;
 
   $MemberStateCopyWith<MemberState> get copyWith;
 }
@@ -34,7 +32,7 @@ abstract class $MemberStateCopyWith<$Res> {
   factory $MemberStateCopyWith(
           MemberState value, $Res Function(MemberState) then) =
       _$MemberStateCopyWithImpl<$Res>;
-  $Res call({double level, String tel});
+  $Res call({List<Member> members});
 }
 
 class _$MemberStateCopyWithImpl<$Res> implements $MemberStateCopyWith<$Res> {
@@ -46,12 +44,10 @@ class _$MemberStateCopyWithImpl<$Res> implements $MemberStateCopyWith<$Res> {
 
   @override
   $Res call({
-    Object level = freezed,
-    Object tel = freezed,
+    Object members = freezed,
   }) {
     return _then(_value.copyWith(
-      level: level == freezed ? _value.level : level as double,
-      tel: tel == freezed ? _value.tel : tel as String,
+      members: members == freezed ? _value.members : members as List<Member>,
     ));
   }
 }
@@ -62,7 +58,7 @@ abstract class _$MemberStateCopyWith<$Res>
           _MemberState value, $Res Function(_MemberState) then) =
       __$MemberStateCopyWithImpl<$Res>;
   @override
-  $Res call({double level, String tel});
+  $Res call({List<Member> members});
 }
 
 class __$MemberStateCopyWithImpl<$Res> extends _$MemberStateCopyWithImpl<$Res>
@@ -76,31 +72,23 @@ class __$MemberStateCopyWithImpl<$Res> extends _$MemberStateCopyWithImpl<$Res>
 
   @override
   $Res call({
-    Object level = freezed,
-    Object tel = freezed,
+    Object members = freezed,
   }) {
     return _then(_MemberState(
-      level: level == freezed ? _value.level : level as double,
-      tel: tel == freezed ? _value.tel : tel as String,
+      members: members == freezed ? _value.members : members as List<Member>,
     ));
   }
 }
 
 class _$_MemberState with DiagnosticableTreeMixin implements _MemberState {
-  const _$_MemberState({this.level = 3, this.tel = '000-0000-0000'})
-      : assert(level != null),
-        assert(tel != null);
+  const _$_MemberState({this.members});
 
-  @JsonKey(defaultValue: 3)
   @override
-  final double level;
-  @JsonKey(defaultValue: '000-0000-0000')
-  @override
-  final String tel;
+  final List<Member> members;
 
   @override
   String toString({DiagnosticLevel minLevel = DiagnosticLevel.info}) {
-    return 'MemberState(level: $level, tel: $tel)';
+    return 'MemberState(members: $members)';
   }
 
   @override
@@ -108,25 +96,20 @@ class _$_MemberState with DiagnosticableTreeMixin implements _MemberState {
     super.debugFillProperties(properties);
     properties
       ..add(DiagnosticsProperty('type', 'MemberState'))
-      ..add(DiagnosticsProperty('level', level))
-      ..add(DiagnosticsProperty('tel', tel));
+      ..add(DiagnosticsProperty('members', members));
   }
 
   @override
   bool operator ==(dynamic other) {
     return identical(this, other) ||
         (other is _MemberState &&
-            (identical(other.level, level) ||
-                const DeepCollectionEquality().equals(other.level, level)) &&
-            (identical(other.tel, tel) ||
-                const DeepCollectionEquality().equals(other.tel, tel)));
+            (identical(other.members, members) ||
+                const DeepCollectionEquality().equals(other.members, members)));
   }
 
   @override
   int get hashCode =>
-      runtimeType.hashCode ^
-      const DeepCollectionEquality().hash(level) ^
-      const DeepCollectionEquality().hash(tel);
+      runtimeType.hashCode ^ const DeepCollectionEquality().hash(members);
 
   @override
   _$MemberStateCopyWith<_MemberState> get copyWith =>
@@ -134,12 +117,10 @@ class _$_MemberState with DiagnosticableTreeMixin implements _MemberState {
 }
 
 abstract class _MemberState implements MemberState {
-  const factory _MemberState({double level, String tel}) = _$_MemberState;
+  const factory _MemberState({List<Member> members}) = _$_MemberState;
 
   @override
-  double get level;
-  @override
-  String get tel;
+  List<Member> get members;
   @override
   _$MemberStateCopyWith<_MemberState> get copyWith;
 }

--- a/lib/pages/member/member_state_controller.dart
+++ b/lib/pages/member/member_state_controller.dart
@@ -27,11 +27,11 @@ class MemberStateController extends StateNotifier<MemberState>
           .copyWith(level: userLevel);
       final newMembers = state.members
         ..removeWhere((member) => member.user.id == id)
-        ..add(member);
-      logger.info('newMembers = $newMembers');
-      newMembers.sort((a, b) => (b.level - a.level).toInt());
+        ..add(member)
+        ..sort((a, b) => (b.level - a.level).toInt());
+      logger.info('newMembers = ${newMembers[0]}');
       state = state.copyWith(members: newMembers);
-      logger.info('state = $state');
+      logger.info('state = ${state.members[0]}');
     }
   }
 

--- a/lib/pages/member/member_state_controller.dart
+++ b/lib/pages/member/member_state_controller.dart
@@ -1,8 +1,5 @@
-import 'package:shiftend/debug_views/globals.dart';
-import 'package:shiftend/models/models.dart';
 import 'package:shiftend/pages/login/login_state.dart';
 import 'package:shiftend/repositories/interfaces/organization_repository_interface.dart';
-import 'package:shiftend/util/logger.dart';
 import 'package:state_notifier/state_notifier.dart';
 import 'member_state.dart';
 

--- a/lib/pages/member/member_state_controller.dart
+++ b/lib/pages/member/member_state_controller.dart
@@ -1,3 +1,8 @@
+import 'package:shiftend/debug_views/globals.dart';
+import 'package:shiftend/models/models.dart';
+import 'package:shiftend/pages/login/login_state.dart';
+import 'package:shiftend/repositories/interfaces/organization_repository_interface.dart';
+import 'package:shiftend/util/logger.dart';
 import 'package:state_notifier/state_notifier.dart';
 import 'member_state.dart';
 
@@ -5,9 +10,28 @@ class MemberStateController extends StateNotifier<MemberState>
     with LocatorMixin {
   MemberStateController() : super(const MemberState());
 
-  void changeLevel(double userLevel) {
+  OrganizationRepositoryInterface get orgRepo =>
+      read<OrganizationRepositoryInterface>();
+
+  LoginState get loginState => read<LoginState>();
+
+  @override
+  void initState() {
+    state = state.copyWith(members: loginState.selectedOrg.members);
+  }
+
+  void changeLevel(String id, double userLevel) {
     if (validateLevel(userLevel)) {
-      state = state.copyWith(level: userLevel);
+      final member = state.members
+          .singleWhere((member) => member.user.id == id)
+          .copyWith(level: userLevel);
+      final newMembers = state.members
+        ..removeWhere((member) => member.user.id == id)
+        ..add(member);
+      logger.info('newMembers = $newMembers');
+      newMembers.sort((a, b) => (b.level - a.level).toInt());
+      state = state.copyWith(members: newMembers);
+      logger.info('state = $state');
     }
   }
 

--- a/lib/pages/member/member_state_controller.dart
+++ b/lib/pages/member/member_state_controller.dart
@@ -29,6 +29,7 @@ class MemberStateController extends StateNotifier<MemberState>
         return member;
       }).toList();
       state = state.copyWith(members: newMembers);
+      orgRepo.update(loginState.selectedOrg.copyWith(members: state.members));
     }
   }
 

--- a/lib/pages/member/member_state_controller.dart
+++ b/lib/pages/member/member_state_controller.dart
@@ -22,16 +22,13 @@ class MemberStateController extends StateNotifier<MemberState>
 
   void changeLevel(String id, double userLevel) {
     if (validateLevel(userLevel)) {
-      final member = state.members
-          .singleWhere((member) => member.user.id == id)
-          .copyWith(level: userLevel);
-      final newMembers = state.members
-        ..removeWhere((member) => member.user.id == id)
-        ..add(member)
-        ..sort((a, b) => (b.level - a.level).toInt());
-      logger.info('newMembers = ${newMembers[0]}');
+      final newMembers = state.members.map((member) {
+        if (member.user.id == id) {
+          return member.copyWith(level: userLevel);
+        }
+        return member;
+      }).toList();
       state = state.copyWith(members: newMembers);
-      logger.info('state = ${state.members[0]}');
     }
   }
 


### PR DESCRIPTION
## 対応する issue

- close #128 
-

## 概要

メンバーリストをfirebaseと接続，

## 変更点・追加点

- MemberStateをitemごとに作成していたが，List<Member>としてpageで一つのStateに変更
- MemberItemの下のWidgetには，memberのIDのみをわたし，内部でproviderを利用して，memberを参照するように修正
-

## 使い方/バグ再現手順

-
-
-

## スクリーンショット等

|           Before           |           After            |
| :------------------------: | :------------------------: |
| <img src="" width="300" /> | <img src="" width="300" /> |

チェックした人：

## その他特記事項
