### PR TITLE
shift情報に変なデータがあったときにスルーする

### DIFF
--- a/lib/repositories/shift_repository.dart
+++ b/lib/repositories/shift_repository.dart
@@ -5,6 +5,7 @@ import 'package:intl/intl.dart';
 import 'package:shiftend/models/shift/shift.dart';
 import 'package:shiftend/repositories/interfaces/shift_repository_interface.dart';
 import 'package:shiftend/repositories/interfaces/user_repository_interface.dart';
+import 'package:shiftend/util/logger.dart';
 
 class ShiftRepository extends ShiftRepositoryInterface {
   ShiftRepository({@required this.firestore, @required this.userRepo})
@@ -57,6 +58,9 @@ class ShiftRepository extends ShiftRepositoryInterface {
         shifts[date] = await Future.wait(list);
       }
     }
+    shifts.forEach((_, value) {
+      value.removeWhere((s) => s == null);
+    });
     return shifts;
   }
 
@@ -95,6 +99,10 @@ class ShiftRepository extends ShiftRepositoryInterface {
   Future<Shift> _fromJson(Map<String, dynamic> rawJson) async {
     final Map<String, dynamic> json = <String, dynamic>{...rawJson};
     final Shift shift = Shift.fromJson(json);
+    if (rawJson['member'] == null) {
+      logger.warning('invalid shift schema');
+      return null;
+    }
     return shift.copyWith(
       member: shift.member.copyWith(
         user: await userRepo

--- a/lib/repositories/shift_request_repository.dart
+++ b/lib/repositories/shift_request_repository.dart
@@ -4,6 +4,7 @@ import 'package:intl/intl.dart';
 
 import 'package:shiftend/models/shift/shift.dart';
 import 'package:shiftend/repositories/interfaces/user_repository_interface.dart';
+import 'package:shiftend/util/logger.dart';
 
 import 'interfaces/shift_request_repository_interface.dart';
 
@@ -58,6 +59,9 @@ class ShiftRequestRepository extends ShiftRequestRepositoryInterface {
         shifts[date] = await Future.wait(list);
       }
     }
+    shifts.forEach((_, value) {
+      value.removeWhere((s) => s == null);
+    });
     return shifts;
   }
 
@@ -96,6 +100,10 @@ class ShiftRequestRepository extends ShiftRequestRepositoryInterface {
   Future<Shift> _fromJson(Map<String, dynamic> rawJson) async {
     final Map<String, dynamic> json = <String, dynamic>{...rawJson};
     final Shift shift = Shift.fromJson(json);
+    if (rawJson['member'] == null) {
+      logger.warning('invalid shift request schema');
+      return null;
+    }
     return shift.copyWith(
       member: shift.member.copyWith(
         user: await userRepo


### PR DESCRIPTION
## 対応する issue

- close #94 
-

## 概要

## 変更点・追加点

- added_member組織のshiftとshift_requestの10月1日のデータにあるような，ゴミデータがあってもコケないように修正
-
-

## 使い方/バグ再現手順

-
-
-

## スクリーンショット等

|           Before           |           After            |
| :------------------------: | :------------------------: |
| <img src="" width="300" /> | <img src="" width="300" /> |

チェックした人：

## その他特記事項
